### PR TITLE
fix: only publish snapshots on manual trigger

### DIFF
--- a/.github/workflows/publish-snapshot.yml
+++ b/.github/workflows/publish-snapshot.yml
@@ -1,8 +1,6 @@
 name: Publish Snapshot
 
 on:
-  push:
-    branches: [ main ]
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
## Summary
- Remove automatic snapshot publishing on every main branch commit
- Snapshots can still be published manually via workflow_dispatch

## Rationale
Publishing snapshots on every commit to main is wasteful and unnecessary. Manual triggering gives better control over when snapshots are released.

## Changes
- Removed `push: branches: [ main ]` trigger from publish-snapshot.yml
- Kept `workflow_dispatch` for manual snapshot releases

🤖 Generated with [Claude Code](https://claude.ai/code)