### PR TITLE
feat: add TTL extension and enhance TaskClaim API

### DIFF
--- a/src/main/java/io/github/panghy/taskqueue/KeyedTaskQueue.java
+++ b/src/main/java/io/github/panghy/taskqueue/KeyedTaskQueue.java
@@ -322,7 +322,7 @@ public class KeyedTaskQueue<K, T> implements TaskQueue<K, T> {
         LOGGER.info(
             "Extended TTL for task: " + describeTask(taskUuid, taskClaim.task()) + " to " + newExpiration);
       } else {
-        // Task has expired but not been reclaimed - we can still extend it
+        // Task has no current claim (could be expired, released, or never claimed) - we can still extend it
         // Re-add to claimed space with new expiration
         tr.set(
             claimedTasks.pack(Tuple.from(newExpiration.toEpochMilli(), taskUuidB)),

--- a/src/main/java/io/github/panghy/taskqueue/SimpleTaskQueue.java
+++ b/src/main/java/io/github/panghy/taskqueue/SimpleTaskQueue.java
@@ -134,4 +134,29 @@ public interface SimpleTaskQueue<T> {
    * @return A future that completes when the task has been failed.
    */
   CompletableFuture<Void> failTask(Transaction tr, TaskClaim<UUID, T> taskClaim);
+
+  /**
+   * Extends the TTL for a claimed task. This allows a worker to request more time to process a task.
+   * If the task has expired but not been claimed by another worker, the TTL can still be extended.
+   * If the task has been claimed by another worker (claim has changed), an exception will be thrown.
+   *
+   * @param taskClaim The task claim to extend.
+   * @param extension The duration from now to set as the new expiration time. Must be positive.
+   * @return A future that completes when the TTL has been extended.
+   */
+  default CompletableFuture<Void> extendTtl(TaskClaim<UUID, T> taskClaim, Duration extension) {
+    return runAsync(tr -> extendTtl(tr, taskClaim, extension));
+  }
+
+  /**
+   * Extends the TTL for a claimed task. This allows a worker to request more time to process a task.
+   * If the task has expired but not been claimed by another worker, the TTL can still be extended.
+   * If the task has been claimed by another worker (claim has changed), an exception will be thrown.
+   *
+   * @param tr        The transaction to use for the operation.
+   * @param taskClaim The task claim to extend.
+   * @param extension The duration from now to set as the new expiration time. Must be positive.
+   * @return A future that completes when the TTL has been extended.
+   */
+  CompletableFuture<Void> extendTtl(Transaction tr, TaskClaim<UUID, T> taskClaim, Duration extension);
 }

--- a/src/main/java/io/github/panghy/taskqueue/SimpleTaskQueueWrapper.java
+++ b/src/main/java/io/github/panghy/taskqueue/SimpleTaskQueueWrapper.java
@@ -51,4 +51,9 @@ public class SimpleTaskQueueWrapper<T> implements SimpleTaskQueue<T> {
   public CompletableFuture<Void> failTask(Transaction tr, TaskClaim<UUID, T> taskClaim) {
     return taskQueue.failTask(tr, taskClaim);
   }
+
+  @Override
+  public CompletableFuture<Void> extendTtl(Transaction tr, TaskClaim<UUID, T> taskClaim, Duration extension) {
+    return taskQueue.extendTtl(tr, taskClaim, extension);
+  }
 }

--- a/src/main/java/io/github/panghy/taskqueue/TaskClaim.java
+++ b/src/main/java/io/github/panghy/taskqueue/TaskClaim.java
@@ -1,10 +1,20 @@
 package io.github.panghy.taskqueue;
 
+import com.apple.foundationdb.Transaction;
 import io.github.panghy.taskqueue.proto.Task;
 import io.github.panghy.taskqueue.proto.TaskKey;
 import io.github.panghy.taskqueue.proto.TaskKeyMetadata;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.UUID;
 import lombok.Builder;
 
+/**
+ * Represents a claimed task with associated metadata and convenience methods for task operations.
+ *
+ * @param <K> the type of the task key
+ * @param <T> the type of the task data
+ */
 @Builder
 public record TaskClaim<K, T>(
     Task taskProto,
@@ -14,11 +24,161 @@ public record TaskClaim<K, T>(
     K taskKey,
     T task) {
 
+  /**
+   * Completes the task, removing it from the queue.
+   * Uses a standalone transaction.
+   */
   public void complete() {
     taskQueue.completeTask(this);
   }
 
+  /**
+   * Completes the task within an existing transaction.
+   *
+   * @param tr the transaction to use
+   */
+  public void complete(Transaction tr) {
+    taskQueue.completeTask(tr, this);
+  }
+
+  /**
+   * Fails the task, causing it to be retried.
+   * Uses a standalone transaction.
+   */
   public void fail() {
     taskQueue.failTask(this);
+  }
+
+  /**
+   * Fails the task within an existing transaction.
+   *
+   * @param tr the transaction to use
+   */
+  public void fail(Transaction tr) {
+    taskQueue.failTask(tr, this);
+  }
+
+  /**
+   * Extends the TTL (time-to-live) for this task claim.
+   * Uses a standalone transaction.
+   *
+   * @param extension the duration from now to set as the new expiration time (must be positive)
+   */
+  public void extend(Duration extension) {
+    taskQueue.extendTtl(this, extension);
+  }
+
+  /**
+   * Extends the TTL within an existing transaction.
+   *
+   * @param tr        the transaction to use
+   * @param extension the duration from now to set as the new expiration time (must be positive)
+   */
+  public void extend(Transaction tr, Duration extension) {
+    taskQueue.extendTtl(tr, this, extension);
+  }
+
+  /**
+   * Gets the number of attempts made on this task.
+   *
+   * @return the attempt count (includes the current attempt)
+   */
+  public long getAttempts() {
+    return taskProto.getAttempts();
+  }
+
+  /**
+   * Gets the task version number.
+   * Higher versions supersede lower versions for the same task key.
+   *
+   * @return the task version
+   */
+  public long getTaskVersion() {
+    return taskProto.getTaskVersion();
+  }
+
+  /**
+   * Gets the unique identifier for this task instance.
+   *
+   * @return the task UUID
+   */
+  public UUID getTaskUuid() {
+    return KeyedTaskQueue.bytesToUuid(taskProto.getTaskUuid().toByteArray());
+  }
+
+  /**
+   * Gets the unique identifier for this claim.
+   *
+   * @return the claim UUID
+   */
+  public UUID getClaimUuid() {
+    return KeyedTaskQueue.bytesToUuid(taskProto.getClaim().toByteArray());
+  }
+
+  /**
+   * Gets the creation time of this task.
+   *
+   * @return the instant when the task was created
+   */
+  public Instant getCreationTime() {
+    return KeyedTaskQueue.toJavaTimestamp(taskProto.getCreationTime());
+  }
+
+  /**
+   * Gets the expected execution time for this task.
+   *
+   * @return the instant when the task was expected to execute
+   */
+  public Instant getExpectedExecutionTime() {
+    return KeyedTaskQueue.toJavaTimestamp(taskKeyProto.getExpectedExecutionTime());
+  }
+
+  /**
+   * Gets the expiration time for this claim.
+   *
+   * @return the instant when this claim expires
+   */
+  public Instant getExpirationTime() {
+    return KeyedTaskQueue.toJavaTimestamp(
+        taskKeyMetadataProto.getCurrentClaim().getExpirationTime());
+  }
+
+  /**
+   * Gets the TTL (time-to-live) duration for this task.
+   *
+   * @return the TTL duration
+   */
+  public Duration getTtl() {
+    return KeyedTaskQueue.toJavaDuration(taskKeyProto.getTtl());
+  }
+
+  /**
+   * Gets the throttle duration for this task.
+   * This is the minimum time between execution attempts.
+   *
+   * @return the throttle duration
+   */
+  public Duration getThrottle() {
+    return KeyedTaskQueue.toJavaDuration(taskKeyProto.getThrottle());
+  }
+
+  /**
+   * Gets the time remaining before this claim expires.
+   *
+   * @return the duration until expiration, or Duration.ZERO if already expired
+   */
+  public Duration getTimeUntilExpiration() {
+    Instant now = taskQueue.getConfig().getInstantSource().instant();
+    Duration remaining = Duration.between(now, getExpirationTime());
+    return remaining.isNegative() ? Duration.ZERO : remaining;
+  }
+
+  /**
+   * Checks if this claim has expired.
+   *
+   * @return true if the claim has expired
+   */
+  public boolean isExpired() {
+    return taskQueue.getConfig().getInstantSource().instant().isAfter(getExpirationTime());
   }
 }

--- a/src/main/java/io/github/panghy/taskqueue/TaskClaim.java
+++ b/src/main/java/io/github/panghy/taskqueue/TaskClaim.java
@@ -7,6 +7,7 @@ import io.github.panghy.taskqueue.proto.TaskKeyMetadata;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
 import lombok.Builder;
 
 /**
@@ -27,35 +28,41 @@ public record TaskClaim<K, T>(
   /**
    * Completes the task, removing it from the queue.
    * Uses a standalone transaction.
+   *
+   * @return A future that completes when the task has been completed.
    */
-  public void complete() {
-    taskQueue.completeTask(this);
+  public CompletableFuture<Void> complete() {
+    return taskQueue.completeTask(this);
   }
 
   /**
    * Completes the task within an existing transaction.
    *
    * @param tr the transaction to use
+   * @return A future that completes when the task has been completed.
    */
-  public void complete(Transaction tr) {
-    taskQueue.completeTask(tr, this);
+  public CompletableFuture<Void> complete(Transaction tr) {
+    return taskQueue.completeTask(tr, this);
   }
 
   /**
    * Fails the task, causing it to be retried.
    * Uses a standalone transaction.
+   *
+   * @return A future that completes when the task has been failed.
    */
-  public void fail() {
-    taskQueue.failTask(this);
+  public CompletableFuture<Void> fail() {
+    return taskQueue.failTask(this);
   }
 
   /**
    * Fails the task within an existing transaction.
    *
    * @param tr the transaction to use
+   * @return A future that completes when the task has been failed.
    */
-  public void fail(Transaction tr) {
-    taskQueue.failTask(tr, this);
+  public CompletableFuture<Void> fail(Transaction tr) {
+    return taskQueue.failTask(tr, this);
   }
 
   /**
@@ -63,9 +70,10 @@ public record TaskClaim<K, T>(
    * Uses a standalone transaction.
    *
    * @param extension the duration from now to set as the new expiration time (must be positive)
+   * @return A future that completes when the TTL has been extended.
    */
-  public void extend(Duration extension) {
-    taskQueue.extendTtl(this, extension);
+  public CompletableFuture<Void> extend(Duration extension) {
+    return taskQueue.extendTtl(this, extension);
   }
 
   /**
@@ -73,9 +81,10 @@ public record TaskClaim<K, T>(
    *
    * @param tr        the transaction to use
    * @param extension the duration from now to set as the new expiration time (must be positive)
+   * @return A future that completes when the TTL has been extended.
    */
-  public void extend(Transaction tr, Duration extension) {
-    taskQueue.extendTtl(tr, this, extension);
+  public CompletableFuture<Void> extend(Transaction tr, Duration extension) {
+    return taskQueue.extendTtl(tr, this, extension);
   }
 
   /**

--- a/src/main/java/io/github/panghy/taskqueue/TaskQueue.java
+++ b/src/main/java/io/github/panghy/taskqueue/TaskQueue.java
@@ -220,4 +220,29 @@ public interface TaskQueue<K, T> {
    * @return A future that completes when the task has been failed.
    */
   CompletableFuture<Void> failTask(Transaction tr, TaskClaim<K, T> taskClaim);
+
+  /**
+   * Extends the TTL for a claimed task. This allows a worker to request more time to process a task.
+   * If the task has expired but not been claimed by another worker, the TTL can still be extended.
+   * If the task has been claimed by another worker (claim has changed), an exception will be thrown.
+   *
+   * @param taskClaim The task claim to extend.
+   * @param extension The duration from now to set as the new expiration time. Must be positive.
+   * @return A future that completes when the TTL has been extended.
+   */
+  default CompletableFuture<Void> extendTtl(TaskClaim<K, T> taskClaim, Duration extension) {
+    return runAsync(tr -> extendTtl(tr, taskClaim, extension));
+  }
+
+  /**
+   * Extends the TTL for a claimed task. This allows a worker to request more time to process a task.
+   * If the task has expired but not been claimed by another worker, the TTL can still be extended.
+   * If the task has been claimed by another worker (claim has changed), an exception will be thrown.
+   *
+   * @param tr        The transaction to use for the operation.
+   * @param taskClaim The task claim to extend.
+   * @param extension The duration from now to set as the new expiration time. Must be positive.
+   * @return A future that completes when the TTL has been extended.
+   */
+  CompletableFuture<Void> extendTtl(Transaction tr, TaskClaim<K, T> taskClaim, Duration extension);
 }

--- a/src/test/java/io/github/panghy/taskqueue/KeyedTaskQueueTest.java
+++ b/src/test/java/io/github/panghy/taskqueue/KeyedTaskQueueTest.java
@@ -1041,17 +1041,18 @@ public class KeyedTaskQueueTest {
     assertThat(claim.getThrottle()).isEqualTo(Duration.ofSeconds(10));
 
     // Test expiration methods
-    assertThat(claim.getExpirationTime()).isEqualTo(Instant.ofEpochMilli(1000 + 5 * 60 * 1000));
+    assertThat(claim.getExpirationTime())
+        .isEqualTo(Instant.ofEpochMilli(1000 + Duration.ofMinutes(5).toMillis()));
     assertThat(claim.isExpired()).isFalse();
     assertThat(claim.getTimeUntilExpiration()).isEqualTo(Duration.ofMinutes(5));
 
     // Move time forward but not past expiration
-    testTime.set(1000 + 3 * 60 * 1000); // 3 minutes later
+    testTime.set(1000 + Duration.ofMinutes(3).toMillis()); // 3 minutes later
     assertThat(claim.isExpired()).isFalse();
     assertThat(claim.getTimeUntilExpiration()).isEqualTo(Duration.ofMinutes(2));
 
     // Move time forward past expiration
-    testTime.set(1000 + 6 * 60 * 1000); // 6 minutes later
+    testTime.set(1000 + Duration.ofMinutes(6).toMillis()); // 6 minutes later
     assertThat(claim.isExpired()).isTrue();
     assertThat(claim.getTimeUntilExpiration()).isEqualTo(Duration.ZERO);
 


### PR DESCRIPTION
## Summary

This PR adds TTL extension capability and significantly enhances the TaskClaim API with useful helper methods.

### Key Features

#### 1. TTL Extension (`extendTtl`)
- Workers can now extend the TTL (time-to-live) of a claimed task when they need more processing time
- Extension works even if the task has expired but hasn't been reclaimed by another worker
- Throws exception if the task has been claimed by a different worker
- Requires positive duration for the extension

#### 2. Enhanced TaskClaim API
Added comprehensive helper methods to TaskClaim:
- **Transaction variants**: `complete(Transaction)`, `fail(Transaction)`, `extend(Transaction, Duration)`
- **Metadata getters**: `getAttempts()`, `getTaskVersion()`, `getTaskUuid()`, `getClaimUuid()`
- **Time helpers**: `getCreationTime()`, `getExpectedExecutionTime()`, `getExpirationTime()`, `getTtl()`, `getThrottle()`
- **Expiration checks**: `isExpired()`, `getTimeUntilExpiration()`

#### 3. Documentation
- All public methods now have comprehensive JavaDoc comments
- Clear parameter and return value documentation

### Testing
- Added comprehensive test coverage for all new functionality
- Tests cover edge cases like expired tasks, competing workers, and invalid inputs
- Coverage: 90% line coverage, 81% branch coverage (exceeds requirements)

### Changes
- Modified TaskQueue interfaces (TaskQueue, SimpleTaskQueue) to add extendTtl
- Implemented extendTtl in KeyedTaskQueue and SimpleTaskQueueWrapper
- Enhanced TaskClaim with 13 new helper methods
- Added 10 new test scenarios

## Test Plan
- [x] All existing tests pass
- [x] New tests for TTL extension scenarios
- [x] New tests for TaskClaim helper methods
- [x] Coverage requirements met (90% line, 80% branch)
- [x] Code formatting applied (spotlessApply)