### PR TITLE
chore: bump version to 0.2.0-SNAPSHOT

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@ allprojects {
 }
 
 group = 'io.github.panghy'
-version = '0.1.0-SNAPSHOT'
+version = '0.2.0-SNAPSHOT'
 
 java {
   sourceCompatibility = JavaVersion.VERSION_17


### PR DESCRIPTION
## Summary
- Bump version to 0.2.0-SNAPSHOT for next development cycle after 0.1.0 release

## Context
Following the 0.1.0 release, updating the version for the next development iteration.