### PR TITLE
chore: bump version to 0.3.0-SNAPSHOT

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,6 +75,12 @@
      --base main
    ```
 
+7. **Auto-merge the Version Bump PR**
+   ```bash
+   # Enable auto-merge for the PR (requires admin or write permissions)
+   gh pr merge --auto --merge
+   ```
+
 ### Automated Publishing
 The `.github/workflows/publish.yml` workflow automatically:
 - Triggers on GitHub release creation


### PR DESCRIPTION
## Summary
- Bump version to 0.3.0-SNAPSHOT for next development cycle after 0.2.0 release
- Add auto-merge command to release process documentation

## Changes
- Version already set to 0.3.0-SNAPSHOT in build.gradle (from previous merge)
- Added step 7 to CLAUDE.md release process: auto-merge command for version bump PRs
- Includes `gh pr merge --auto --merge` to streamline the release workflow

## Context
Following the 0.2.0 release, updating the version for the next development iteration and improving the release process documentation.