### PR TITLE
docs: update auto-merge command to use rebase strategy

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,7 +78,7 @@
 7. **Auto-merge the Version Bump PR**
    ```bash
    # Enable auto-merge for the PR (requires admin or write permissions)
-   gh pr merge --auto --merge
+   gh pr merge --auto --rebase
    ```
 
 ### Automated Publishing


### PR DESCRIPTION
## Summary
Updated the release process documentation to use `--rebase` instead of `--merge` for auto-merge commands.

## Changes
- Changed step 7 in CLAUDE.md from `gh pr merge --auto --merge` to `gh pr merge --auto --rebase`
- This aligns with the repository's merge strategy preferences

## Rationale
The repository doesn't allow merge commits, so using `--rebase` ensures the auto-merge command works correctly for version bump PRs.