### PR TITLE
feat: add isEmpty method to check if queue is empty

### DIFF
--- a/src/main/java/io/github/panghy/taskqueue/KeyedTaskQueue.java
+++ b/src/main/java/io/github/panghy/taskqueue/KeyedTaskQueue.java
@@ -1017,4 +1017,13 @@ public class KeyedTaskQueue<K, T> implements TaskQueue<K, T> {
   static Duration toJavaDuration(com.google.protobuf.Duration duration) {
     return Duration.ofSeconds(duration.getSeconds()).plusNanos(duration.getNanos());
   }
+
+  @Override
+  public CompletableFuture<Boolean> isEmpty(Transaction tr) {
+    CompletableFuture<Boolean> unclaimedEmpty =
+        tr.getRange(unclaimedTasks.range(), 1).asList().thenApply(List::isEmpty);
+    CompletableFuture<Boolean> claimedEmpty =
+        tr.getRange(claimedTasks.range(), 1).asList().thenApply(List::isEmpty);
+    return unclaimedEmpty.thenCombine(claimedEmpty, (u, c) -> u && c);
+  }
 }

--- a/src/main/java/io/github/panghy/taskqueue/SimpleTaskQueue.java
+++ b/src/main/java/io/github/panghy/taskqueue/SimpleTaskQueue.java
@@ -159,4 +159,21 @@ public interface SimpleTaskQueue<T> {
    * @return A future that completes when the TTL has been extended.
    */
   CompletableFuture<Void> extendTtl(Transaction tr, TaskClaim<UUID, T> taskClaim, Duration extension);
+
+  /**
+   * Checks whether the queue is empty.
+   *
+   * @return A future that completes with true if the queue is empty, false otherwise.
+   */
+  default CompletableFuture<Boolean> isEmpty() {
+    return runAsync(this::isEmpty);
+  }
+
+  /**
+   * Checks whether the queue is empty.
+   *
+   * @param tr The transaction to use for the operation.
+   * @return A future that completes with true if the queue is empty, false otherwise.
+   */
+  CompletableFuture<Boolean> isEmpty(Transaction tr);
 }

--- a/src/main/java/io/github/panghy/taskqueue/SimpleTaskQueueWrapper.java
+++ b/src/main/java/io/github/panghy/taskqueue/SimpleTaskQueueWrapper.java
@@ -56,4 +56,9 @@ public class SimpleTaskQueueWrapper<T> implements SimpleTaskQueue<T> {
   public CompletableFuture<Void> extendTtl(Transaction tr, TaskClaim<UUID, T> taskClaim, Duration extension) {
     return taskQueue.extendTtl(tr, taskClaim, extension);
   }
+
+  @Override
+  public CompletableFuture<Boolean> isEmpty(Transaction tr) {
+    return taskQueue.isEmpty(tr);
+  }
 }

--- a/src/main/java/io/github/panghy/taskqueue/TaskQueue.java
+++ b/src/main/java/io/github/panghy/taskqueue/TaskQueue.java
@@ -245,4 +245,21 @@ public interface TaskQueue<K, T> {
    * @return A future that completes when the TTL has been extended.
    */
   CompletableFuture<Void> extendTtl(Transaction tr, TaskClaim<K, T> taskClaim, Duration extension);
+
+  /**
+   * Checks whether the queue is empty.
+   *
+   * @return A future that completes with true if the queue is empty, false otherwise.
+   */
+  default CompletableFuture<Boolean> isEmpty() {
+    return runAsync(this::isEmpty);
+  }
+
+  /**
+   * Checks whether the queue is empty.
+   *
+   * @param tr The transaction to use for the operation.
+   * @return A future that completes with true if the queue is empty, false otherwise.
+   */
+  CompletableFuture<Boolean> isEmpty(Transaction tr);
 }


### PR DESCRIPTION
## Summary
- Add `isEmpty()` method to both `TaskQueue` and `SimpleTaskQueue` interfaces
- Returns `CompletableFuture<Boolean>` indicating whether the queue has any tasks (unclaimed or claimed)

## Implementation
- **KeyedTaskQueue**: Checks both `unclaimedTasks` and `claimedTasks` subspaces using efficient range queries with limit 1
- **SimpleTaskQueueWrapper**: Delegates to the underlying `TaskQueue` implementation
- Both transactional `isEmpty(Transaction)` and standalone `isEmpty()` methods provided

## Testing
- Added comprehensive tests for both `KeyedTaskQueue` and `SimpleTaskQueue`
- Tests cover empty queue, single task lifecycle, multiple tasks, and transactional usage
- All tests passing ✅

## Use Cases
- Monitor queue status for operational metrics
- Implement conditional logic based on queue state
- Useful for testing and debugging queue behavior