### PR TITLE
fix: prevent accidental logging of sensitive proto data

### DIFF
--- a/src/main/java/io/github/panghy/taskqueue/TaskClaim.java
+++ b/src/main/java/io/github/panghy/taskqueue/TaskClaim.java
@@ -190,4 +190,25 @@ public record TaskClaim<K, T>(
   public boolean isExpired() {
     return taskQueue.getConfig().getInstantSource().instant().isAfter(getExpirationTime());
   }
+
+  /**
+   * Returns a string representation that excludes sensitive proto data.
+   * This prevents accidental logging of task content.
+   *
+   * @return a safe string representation
+   */
+  @Override
+  public String toString() {
+    String taskName = task == null
+        ? "null"
+        : taskQueue.getConfig().getTaskNameExtractor().apply(task);
+    return "TaskClaim{" + "taskUuid="
+        + getTaskUuid() + ", taskName="
+        + taskName + ", taskKey="
+        + taskKey + ", attempts="
+        + getAttempts() + ", version="
+        + getTaskVersion() + ", claimUuid="
+        + getClaimUuid() + ", expirationTime="
+        + getExpirationTime() + '}';
+  }
 }


### PR DESCRIPTION
## Summary
- Override `toString()` method in `TaskClaim` to exclude proto fields
- Only include safe metadata in string representation (UUIDs, task name, timestamps)

## Security Improvement
The default `toString()` for records includes all fields, which could potentially expose sensitive proto data if `TaskClaim` is ever logged directly. This PR adds a custom `toString()` that only includes non-sensitive metadata.

## What's Included in toString()
- Task UUID
- Task name (via TaskNameExtractor)
- Task key
- Attempt count
- Version number  
- Claim UUID
- Expiration time

## What's Excluded
- `taskProto` - Raw protocol buffer data
- `taskKeyProto` - Raw protocol buffer data
- `taskKeyMetadataProto` - Raw protocol buffer data
- `task` - Actual task data content (only name is included via extractor)

## Testing
- All existing tests pass ✅
- The existing logging already uses `describeTask()` which only logs UUID and task name
- This change adds defense-in-depth to prevent future accidental data exposure