### PR TITLE
feat: add hasVisibleUnclaimedTasks method to check for ready tasks

### DIFF
--- a/src/main/java/io/github/panghy/taskqueue/SimpleTaskQueue.java
+++ b/src/main/java/io/github/panghy/taskqueue/SimpleTaskQueue.java
@@ -176,4 +176,25 @@ public interface SimpleTaskQueue<T> {
    * @return A future that completes with true if the queue is empty, false otherwise.
    */
   CompletableFuture<Boolean> isEmpty(Transaction tr);
+
+  /**
+   * Checks whether the queue has any visible unclaimed tasks ready to be processed.
+   * This only returns true if there are unclaimed tasks whose visibility time has passed.
+   * Tasks that are claimed or scheduled for future execution are not counted.
+   *
+   * @return A future that completes with true if there are visible unclaimed tasks, false otherwise.
+   */
+  default CompletableFuture<Boolean> hasVisibleUnclaimedTasks() {
+    return runAsync(this::hasVisibleUnclaimedTasks);
+  }
+
+  /**
+   * Checks whether the queue has any visible unclaimed tasks ready to be processed.
+   * This only returns true if there are unclaimed tasks whose visibility time has passed.
+   * Tasks that are claimed or scheduled for future execution are not counted.
+   *
+   * @param tr The transaction to use for the operation.
+   * @return A future that completes with true if there are visible unclaimed tasks, false otherwise.
+   */
+  CompletableFuture<Boolean> hasVisibleUnclaimedTasks(Transaction tr);
 }

--- a/src/main/java/io/github/panghy/taskqueue/SimpleTaskQueueWrapper.java
+++ b/src/main/java/io/github/panghy/taskqueue/SimpleTaskQueueWrapper.java
@@ -61,4 +61,9 @@ public class SimpleTaskQueueWrapper<T> implements SimpleTaskQueue<T> {
   public CompletableFuture<Boolean> isEmpty(Transaction tr) {
     return taskQueue.isEmpty(tr);
   }
+
+  @Override
+  public CompletableFuture<Boolean> hasVisibleUnclaimedTasks(Transaction tr) {
+    return taskQueue.hasVisibleUnclaimedTasks(tr);
+  }
 }

--- a/src/main/java/io/github/panghy/taskqueue/TaskQueue.java
+++ b/src/main/java/io/github/panghy/taskqueue/TaskQueue.java
@@ -262,4 +262,25 @@ public interface TaskQueue<K, T> {
    * @return A future that completes with true if the queue is empty, false otherwise.
    */
   CompletableFuture<Boolean> isEmpty(Transaction tr);
+
+  /**
+   * Checks whether the queue has any visible unclaimed tasks ready to be processed.
+   * This only returns true if there are unclaimed tasks whose visibility time has passed.
+   * Tasks that are claimed or scheduled for future execution are not counted.
+   *
+   * @return A future that completes with true if there are visible unclaimed tasks, false otherwise.
+   */
+  default CompletableFuture<Boolean> hasVisibleUnclaimedTasks() {
+    return runAsync(this::hasVisibleUnclaimedTasks);
+  }
+
+  /**
+   * Checks whether the queue has any visible unclaimed tasks ready to be processed.
+   * This only returns true if there are unclaimed tasks whose visibility time has passed.
+   * Tasks that are claimed or scheduled for future execution are not counted.
+   *
+   * @param tr The transaction to use for the operation.
+   * @return A future that completes with true if there are visible unclaimed tasks, false otherwise.
+   */
+  CompletableFuture<Boolean> hasVisibleUnclaimedTasks(Transaction tr);
 }


### PR DESCRIPTION
## Summary
- Add `hasVisibleUnclaimedTasks()` method to check if there are any unclaimed tasks ready to be processed
- Returns `CompletableFuture<Boolean>` indicating whether there are visible unclaimed tasks

## Implementation
- **Method signature**: Similar to `isEmpty()`, provides both transactional and standalone variants
- **Visibility check**: Only returns true for unclaimed tasks whose visibility time has passed
- **Efficient query**: Uses range query with limit 1 to check for existence of visible tasks
- **Time-based filtering**: Tasks scheduled for future execution are not counted as visible

## Use Cases
- Monitor queue for work availability without claiming tasks
- Implement conditional processing based on queue state
- Useful for polling strategies and worker coordination
- Different from `isEmpty()` which checks all tasks regardless of visibility

## Testing
- Comprehensive tests for both `KeyedTaskQueue` and `SimpleTaskQueue`
- Tests cover immediate visibility, delayed tasks, and mixed visibility scenarios
- Uses simulated time for deterministic testing
- All tests passing ✅

## API Addition
```java
// Check if any tasks are ready for processing
CompletableFuture<Boolean> hasWork = queue.hasVisibleUnclaimedTasks();
if (hasWork.get()) {
    // Process available tasks
}
```