### PR TITLE
perf: cancel unnecessary watch when immediate retry is needed

### DIFF
--- a/src/main/java/io/github/panghy/taskqueue/KeyedTaskQueue.java
+++ b/src/main/java/io/github/panghy/taskqueue/KeyedTaskQueue.java
@@ -333,8 +333,8 @@ public class KeyedTaskQueue<K, T> implements TaskQueue<K, T> {
                             .exceptionally($ -> null)
                             .thenApply($ -> true);
                       }
-                      watchF.cancel(true);
-                      return completedFuture(true);
+                      return watchF.thenApply($ -> true)
+                          .whenComplete((r, t) -> watchF.cancel(true));
                     }
                     return watchF.thenApply($ -> true);
                   });

--- a/src/main/java/io/github/panghy/taskqueue/KeyedTaskQueue.java
+++ b/src/main/java/io/github/panghy/taskqueue/KeyedTaskQueue.java
@@ -333,6 +333,7 @@ public class KeyedTaskQueue<K, T> implements TaskQueue<K, T> {
                             .exceptionally($ -> null)
                             .thenApply($ -> true);
                       }
+                      watchF.cancel(true);
                       return completedFuture(true);
                     }
                     return watchF.thenApply($ -> true);

--- a/src/main/java/io/github/panghy/taskqueue/KeyedTaskQueue.java
+++ b/src/main/java/io/github/panghy/taskqueue/KeyedTaskQueue.java
@@ -333,8 +333,8 @@ public class KeyedTaskQueue<K, T> implements TaskQueue<K, T> {
                             .exceptionally($ -> null)
                             .thenApply($ -> true);
                       }
-                      return watchF.thenApply($ -> true)
-                          .whenComplete((r, t) -> watchF.cancel(true));
+                      watchF.cancel(true);
+                      return completedFuture(true);
                     }
                     return watchF.thenApply($ -> true);
                   });


### PR DESCRIPTION
## Summary
- Cancel the watch future when sleepTime <= 0 to avoid holding unnecessary resources

## Details
When determining whether to wait or retry immediately in `awaitAndClaimTask`, if the calculated sleep time is 0 or negative (meaning a task is already available or expired), we immediately return true to retry. 

However, the watch future was still created and left uncancelled. This small optimization cancels the watch future in this case to free up any associated resources.

## Test Plan
- All existing tests continue to pass
- This is a minor performance optimization that doesn't change behavior