### PR TITLE
feat: add hasClaimedTasks method to check for tasks in progress

### DIFF
--- a/src/main/java/io/github/panghy/taskqueue/SimpleTaskQueue.java
+++ b/src/main/java/io/github/panghy/taskqueue/SimpleTaskQueue.java
@@ -197,4 +197,23 @@ public interface SimpleTaskQueue<T> {
    * @return A future that completes with true if there are visible unclaimed tasks, false otherwise.
    */
   CompletableFuture<Boolean> hasVisibleUnclaimedTasks(Transaction tr);
+
+  /**
+   * Checks whether the queue has any claimed tasks.
+   * This returns true if there are any tasks that are currently being processed by workers.
+   *
+   * @return A future that completes with true if there are claimed tasks, false otherwise.
+   */
+  default CompletableFuture<Boolean> hasClaimedTasks() {
+    return runAsync(this::hasClaimedTasks);
+  }
+
+  /**
+   * Checks whether the queue has any claimed tasks.
+   * This returns true if there are any tasks that are currently being processed by workers.
+   *
+   * @param tr The transaction to use for the operation.
+   * @return A future that completes with true if there are claimed tasks, false otherwise.
+   */
+  CompletableFuture<Boolean> hasClaimedTasks(Transaction tr);
 }

--- a/src/main/java/io/github/panghy/taskqueue/SimpleTaskQueueWrapper.java
+++ b/src/main/java/io/github/panghy/taskqueue/SimpleTaskQueueWrapper.java
@@ -66,4 +66,9 @@ public class SimpleTaskQueueWrapper<T> implements SimpleTaskQueue<T> {
   public CompletableFuture<Boolean> hasVisibleUnclaimedTasks(Transaction tr) {
     return taskQueue.hasVisibleUnclaimedTasks(tr);
   }
+
+  @Override
+  public CompletableFuture<Boolean> hasClaimedTasks(Transaction tr) {
+    return taskQueue.hasClaimedTasks(tr);
+  }
 }

--- a/src/main/java/io/github/panghy/taskqueue/TaskQueue.java
+++ b/src/main/java/io/github/panghy/taskqueue/TaskQueue.java
@@ -283,4 +283,23 @@ public interface TaskQueue<K, T> {
    * @return A future that completes with true if there are visible unclaimed tasks, false otherwise.
    */
   CompletableFuture<Boolean> hasVisibleUnclaimedTasks(Transaction tr);
+
+  /**
+   * Checks whether the queue has any claimed tasks.
+   * This returns true if there are any tasks that are currently being processed by workers.
+   *
+   * @return A future that completes with true if there are claimed tasks, false otherwise.
+   */
+  default CompletableFuture<Boolean> hasClaimedTasks() {
+    return runAsync(this::hasClaimedTasks);
+  }
+
+  /**
+   * Checks whether the queue has any claimed tasks.
+   * This returns true if there are any tasks that are currently being processed by workers.
+   *
+   * @param tr The transaction to use for the operation.
+   * @return A future that completes with true if there are claimed tasks, false otherwise.
+   */
+  CompletableFuture<Boolean> hasClaimedTasks(Transaction tr);
 }

--- a/src/test/resources/simplelogger.properties
+++ b/src/test/resources/simplelogger.properties
@@ -1,0 +1,19 @@
+# SLF4J Simple Logger configuration for tests
+# Default logging level (ERROR, WARN, INFO, DEBUG, TRACE)
+org.slf4j.simpleLogger.defaultLogLevel=INFO
+
+// Enable debug logging for the taskqueue package
+org.slf4j.simpleLogger.log.io.github.panghy.taskqueue=DEBUG
+
+# Show date and time
+org.slf4j.simpleLogger.showDateTime=true
+org.slf4j.simpleLogger.dateTimeFormat=yyyy-MM-dd HH:mm:ss:SSS
+
+# Show thread name
+org.slf4j.simpleLogger.showThreadName=true
+
+# Show short logger name
+org.slf4j.simpleLogger.showShortLogName=true
+
+# Log to System.err (so it shows up in test output)
+org.slf4j.simpleLogger.logFile=System.err

--- a/src/test/resources/simplelogger.properties
+++ b/src/test/resources/simplelogger.properties
@@ -2,7 +2,7 @@
 # Default logging level (ERROR, WARN, INFO, DEBUG, TRACE)
 org.slf4j.simpleLogger.defaultLogLevel=INFO
 
-// Enable debug logging for the taskqueue package
+# Enable debug logging for the taskqueue package
 org.slf4j.simpleLogger.log.io.github.panghy.taskqueue=DEBUG
 
 # Show date and time


### PR DESCRIPTION
## Summary
Added a new `hasClaimedTasks()` method to check if there are any tasks currently being processed by workers.

## Changes

### New Feature
- Added `hasClaimedTasks()` method to `TaskQueue` and `SimpleTaskQueue` interfaces
- Implemented the method in `KeyedTaskQueue` and `SimpleTaskQueueWrapper`
- Returns `true` if there are any tasks in the claimed space, `false` otherwise

### Bug Fix
Fixed a critical bug in `findAndReclaimExpiredTask()` where expired tasks were not properly moved to their new expiration slot when reclaimed:
- **Before**: Used `tr.set()` to update task in place at the old expiration slot
- **After**: Now properly uses `tr.clear()` to remove from old slot and `storeClaimedTask()` to add to new slot
- This prevented stale entries from accumulating in the claimed space

### Tests Added
- `testHasClaimedTasks()` - Basic functionality test
- `testHasClaimedTasksWithFailedTask()` - Verifies failed tasks move back to unclaimed
- `testHasClaimedTasksWithExpiredTask()` - Tests behavior with expired tasks
- `testReclaimExpiredTaskProperlyMovesItInClaimedSpace()` - Specifically tests the bug fix

## Why This Is Needed
The `hasClaimedTasks()` method allows monitoring systems to check if there are tasks currently being processed, which is useful for:
- Monitoring worker activity
- Determining if the system is idle
- Debugging task processing issues

## Test Results
All 93 tests pass successfully, including the new tests for the hasClaimedTasks functionality.