### PR TITLE
feat: add awaitQueueEmpty method to detect when queue is empty

### DIFF
--- a/src/main/java/io/github/panghy/taskqueue/SimpleTaskQueue.java
+++ b/src/main/java/io/github/panghy/taskqueue/SimpleTaskQueue.java
@@ -216,4 +216,26 @@ public interface SimpleTaskQueue<T> {
    * @return A future that completes with true if there are claimed tasks, false otherwise.
    */
   CompletableFuture<Boolean> hasClaimedTasks(Transaction tr);
+
+  /**
+   * Waits for the queue to become completely empty (no unclaimed or claimed tasks).
+   * This method returns a future that completes when there are no tasks in the queue.
+   * It uses a watch similar to awaitAndClaimTask to be notified when the queue state changes.
+   *
+   * @return A future that completes when the queue is empty.
+   */
+  default CompletableFuture<Void> awaitQueueEmpty() {
+    return awaitQueueEmpty(getConfig().getDatabase());
+  }
+
+  /**
+   * Waits for the queue to become completely empty (no unclaimed or claimed tasks).
+   * This method returns a future that completes when there are no tasks in the queue.
+   * It uses a watch similar to awaitAndClaimTask to be notified when the queue state changes.
+   *
+   * @param db The database to use for the operation. This must be the actual database and not a transaction as we
+   *           need to use a transaction to watch a key.
+   * @return A future that completes when the queue is empty.
+   */
+  CompletableFuture<Void> awaitQueueEmpty(Database db);
 }

--- a/src/main/java/io/github/panghy/taskqueue/SimpleTaskQueueWrapper.java
+++ b/src/main/java/io/github/panghy/taskqueue/SimpleTaskQueueWrapper.java
@@ -71,4 +71,9 @@ public class SimpleTaskQueueWrapper<T> implements SimpleTaskQueue<T> {
   public CompletableFuture<Boolean> hasClaimedTasks(Transaction tr) {
     return taskQueue.hasClaimedTasks(tr);
   }
+
+  @Override
+  public CompletableFuture<Void> awaitQueueEmpty(Database db) {
+    return taskQueue.awaitQueueEmpty(db);
+  }
 }

--- a/src/main/java/io/github/panghy/taskqueue/TaskQueue.java
+++ b/src/main/java/io/github/panghy/taskqueue/TaskQueue.java
@@ -302,4 +302,26 @@ public interface TaskQueue<K, T> {
    * @return A future that completes with true if there are claimed tasks, false otherwise.
    */
   CompletableFuture<Boolean> hasClaimedTasks(Transaction tr);
+
+  /**
+   * Waits for the queue to become completely empty (no unclaimed or claimed tasks).
+   * This method returns a future that completes when there are no tasks in the queue.
+   * It uses a watch similar to awaitAndClaimTask to be notified when the queue state changes.
+   *
+   * @return A future that completes when the queue is empty.
+   */
+  default CompletableFuture<Void> awaitQueueEmpty() {
+    return awaitQueueEmpty(getConfig().getDatabase());
+  }
+
+  /**
+   * Waits for the queue to become completely empty (no unclaimed or claimed tasks).
+   * This method returns a future that completes when there are no tasks in the queue.
+   * It uses a watch similar to awaitAndClaimTask to be notified when the queue state changes.
+   *
+   * @param db The database to use for the operation. This must be the actual database and not a transaction as we
+   *           need to use a transaction to watch a key.
+   * @return A future that completes when the queue is empty.
+   */
+  CompletableFuture<Void> awaitQueueEmpty(Database db);
 }


### PR DESCRIPTION
## Summary

This PR adds a new `awaitQueueEmpty()` method that allows users to wait until the entire queue becomes empty (no unclaimed or claimed tasks). This is useful for detecting when there is no work left to be processed.

## Implementation

The method uses a watch-based mechanism similar to `awaitAndClaimTask()`:
- Checks if both unclaimed and claimed queues are empty
- If not empty, sets up a watch on the queue's watch key
- Waits for either the watch to trigger or for claimed tasks to expire
- Returns when the queue becomes completely empty

## Key Changes

1. **Added interface methods**:
   - `awaitQueueEmpty()` and `awaitQueueEmpty(Database db)` in TaskQueue interface
   - Same methods in SimpleTaskQueue interface

2. **Implementation in KeyedTaskQueue**:
   - Uses `AsyncUtil.whileTrue` pattern like awaitAndClaimTask
   - Checks both unclaimed and claimed ranges
   - Sets up watch when queue is not empty
   - Handles timeout for expired claimed tasks

3. **Watch key notification**:
   - Added `incrementWatchKey(tr)` call in `completeTask` when a task is fully removed
   - This ensures awaitQueueEmpty watchers are notified when the queue becomes empty

4. **Delegation in SimpleTaskQueueWrapper**:
   - Delegates to the wrapped TaskQueue implementation

## Testing

Added comprehensive tests covering:
- Empty queue (immediate completion)
- Queue with unclaimed tasks
- Queue with claimed tasks  
- Multiple tasks being processed
- Failed tasks returning to queue
- Expired tasks being reclaimed
- Delayed tasks not yet visible

All tests pass successfully with full code coverage.

## Use Case

This feature is particularly useful for:
- Test scenarios where you need to wait for all tasks to complete
- Graceful shutdown procedures
- Monitoring when a batch of work is finished
- Detecting idle periods in the task queue