### PR TITLE
Add Dead Letter Queue (DLQ) support

### DIFF
--- a/src/main/java/io/github/panghy/taskqueue/KeyedTaskQueue.java
+++ b/src/main/java/io/github/panghy/taskqueue/KeyedTaskQueue.java
@@ -17,6 +17,7 @@ import com.apple.foundationdb.tuple.Tuple;
 import com.google.protobuf.ByteString;
 import com.google.protobuf.InvalidProtocolBufferException;
 import com.google.protobuf.Timestamp;
+import io.github.panghy.taskqueue.proto.DeadLetteredTask;
 import io.github.panghy.taskqueue.proto.Task;
 import io.github.panghy.taskqueue.proto.TaskKey;
 import io.github.panghy.taskqueue.proto.TaskKeyMetadata;
@@ -64,6 +65,9 @@ public class KeyedTaskQueue<K, T> implements TaskQueue<K, T> {
   private final LongCounter tasksClaimed;
   private final LongCounter tasksCompleted;
   private final LongCounter tasksFailed;
+  private final LongCounter dlqAdded;
+  private final LongCounter dlqRedriven;
+  private final LongCounter dlqPurged;
   private final LongHistogram taskProcessingDuration;
   private final LongHistogram taskWaitTime;
 
@@ -80,6 +84,7 @@ public class KeyedTaskQueue<K, T> implements TaskQueue<K, T> {
   private final DirectorySubspace unclaimedTasks;
   private final DirectorySubspace claimedTasks;
   private final DirectorySubspace taskKeys;
+  private final DirectorySubspace dlqTasks;
   private final byte[] watchKey;
   private final String queuePath;
 
@@ -91,11 +96,13 @@ public class KeyedTaskQueue<K, T> implements TaskQueue<K, T> {
       DirectorySubspace unclaimedTasks,
       DirectorySubspace claimedTasks,
       DirectorySubspace taskKeys,
+      DirectorySubspace dlqTasks,
       byte[] watchKey) {
     this.config = config;
     this.unclaimedTasks = unclaimedTasks;
     this.claimedTasks = claimedTasks;
     this.taskKeys = taskKeys;
+    this.dlqTasks = dlqTasks;
     this.watchKey = watchKey;
 
     // Get the queue path from the directory
@@ -126,6 +133,21 @@ public class KeyedTaskQueue<K, T> implements TaskQueue<K, T> {
         .setUnit("tasks")
         .build();
 
+    this.dlqAdded = meter.counterBuilder("taskqueue.dlq.added")
+        .setDescription("Number of tasks added to the dead letter queue")
+        .setUnit("tasks")
+        .build();
+
+    this.dlqRedriven = meter.counterBuilder("taskqueue.dlq.redriven")
+        .setDescription("Number of tasks redriven from the dead letter queue")
+        .setUnit("tasks")
+        .build();
+
+    this.dlqPurged = meter.counterBuilder("taskqueue.dlq.purged")
+        .setDescription("Number of tasks purged from the dead letter queue")
+        .setUnit("tasks")
+        .build();
+
     this.taskProcessingDuration = meter.histogramBuilder("taskqueue.task.processing.duration")
         .setDescription("Duration of task processing")
         .setUnit("ms")
@@ -153,15 +175,17 @@ public class KeyedTaskQueue<K, T> implements TaskQueue<K, T> {
     var unclaimedTaskF = config.getDirectory().createOrOpen(context, List.of("unclaimed_tasks"));
     var claimedTaskF = config.getDirectory().createOrOpen(context, List.of("claimed_tasks"));
     var taskKeyF = config.getDirectory().createOrOpen(context, List.of("task_keys"));
+    var dlqF = config.getDirectory().createOrOpen(context, List.of("dlq"));
     var watchKeyF =
         config.getDirectory().createOrOpen(context, List.of("watch")).thenApply(Subspace::getKey);
     var watchKeyWriteF = watchKeyF.thenAccept(watchKey -> context.run(tr -> {
       tr.set(watchKey, ONE);
       return null;
     }));
-    return allOf(unclaimedTaskF, claimedTaskF, taskKeyF, watchKeyF, watchKeyWriteF)
+    return allOf(unclaimedTaskF, claimedTaskF, taskKeyF, dlqF, watchKeyF, watchKeyWriteF)
         .thenApply(v -> new KeyedTaskQueue<>(
-            config, unclaimedTaskF.join(), claimedTaskF.join(), taskKeyF.join(), watchKeyF.join()));
+            config, unclaimedTaskF.join(), claimedTaskF.join(), taskKeyF.join(), dlqF.join(),
+            watchKeyF.join()));
   }
 
   @Override
@@ -577,7 +601,7 @@ public class KeyedTaskQueue<K, T> implements TaskQueue<K, T> {
   }
 
   @Override
-  public CompletableFuture<Void> failTask(Transaction tr, TaskClaim<K, T> taskClaim) {
+  public CompletableFuture<Void> failTask(Transaction tr, TaskClaim<K, T> taskClaim, String failureReason) {
     Span span = tracer.spanBuilder("taskqueue.failTask")
         .setSpanKind(SpanKind.INTERNAL)
         .setAttribute(TASK_UUID, taskClaim.getTaskUuid().toString())
@@ -1169,5 +1193,30 @@ public class KeyedTaskQueue<K, T> implements TaskQueue<K, T> {
             return null;
           }
         });
+  }
+
+  @Override
+  public CompletableFuture<Void> redriveFromDlq(Transaction tr, K taskKey) {
+    throw new UnsupportedOperationException("DLQ redrive not yet implemented");
+  }
+
+  @Override
+  public CompletableFuture<Integer> redriveFromDlq(Transaction tr, int count) {
+    throw new UnsupportedOperationException("DLQ redrive not yet implemented");
+  }
+
+  @Override
+  public CompletableFuture<Void> purgeDlq(Transaction tr) {
+    throw new UnsupportedOperationException("DLQ purge not yet implemented");
+  }
+
+  @Override
+  public CompletableFuture<Long> getDlqSize(Transaction tr) {
+    throw new UnsupportedOperationException("DLQ size not yet implemented");
+  }
+
+  @Override
+  public CompletableFuture<List<DeadLetteredTask>> listDlqTasks(Transaction tr, int limit) {
+    throw new UnsupportedOperationException("DLQ list not yet implemented");
   }
 }

--- a/src/main/java/io/github/panghy/taskqueue/KeyedTaskQueue.java
+++ b/src/main/java/io/github/panghy/taskqueue/KeyedTaskQueue.java
@@ -648,18 +648,18 @@ public class KeyedTaskQueue<K, T> implements TaskQueue<K, T> {
                   taskClaim.taskProto().getAttempts());
               if (config.isDlqEnabled()) {
                 // Move to dead letter queue.
+                Instant deadLetteredInstant =
+                    config.getInstantSource().instant();
                 DeadLetteredTask dlqEntry = DeadLetteredTask.newBuilder()
                     .setTaskUuid(taskClaim.taskProto().getTaskUuid())
                     .setTaskKey(taskKeyBytes)
                     .setTask(taskClaim.taskKeyProto().getTask())
                     .setCreationTime(taskClaim.taskProto().getCreationTime())
-                    .setDeadLetteredTime(fromJavaTimestamp(
-                        config.getInstantSource().instant()))
+                    .setDeadLetteredTime(fromJavaTimestamp(deadLetteredInstant))
                     .setFailureReason(failureReason != null ? failureReason : "")
                     .setAttempts(taskClaim.taskProto().getAttempts())
                     .build();
-                long deadLetteredTimeMillis =
-                    config.getInstantSource().instant().toEpochMilli();
+                long deadLetteredTimeMillis = deadLetteredInstant.toEpochMilli();
                 tr.set(
                     dlqTasks.pack(Tuple.from(
                         deadLetteredTimeMillis,

--- a/src/main/java/io/github/panghy/taskqueue/KeyedTaskQueue.java
+++ b/src/main/java/io/github/panghy/taskqueue/KeyedTaskQueue.java
@@ -68,7 +68,6 @@ public class KeyedTaskQueue<K, T> implements TaskQueue<K, T> {
   private final LongCounter tasksFailed;
   private final LongCounter dlqAdded;
   private final LongCounter dlqRedriven;
-  private final LongCounter dlqPurged;
   private final LongHistogram taskProcessingDuration;
   private final LongHistogram taskWaitTime;
 
@@ -141,11 +140,6 @@ public class KeyedTaskQueue<K, T> implements TaskQueue<K, T> {
 
     this.dlqRedriven = meter.counterBuilder("taskqueue.dlq.redriven")
         .setDescription("Number of tasks redriven from the dead letter queue")
-        .setUnit("tasks")
-        .build();
-
-    this.dlqPurged = meter.counterBuilder("taskqueue.dlq.purged")
-        .setDescription("Number of tasks purged from the dead letter queue")
         .setUnit("tasks")
         .build();
 
@@ -667,7 +661,13 @@ public class KeyedTaskQueue<K, T> implements TaskQueue<K, T> {
                 long deadLetteredTimeMillis =
                     config.getInstantSource().instant().toEpochMilli();
                 tr.set(
-                    dlqTasks.pack(Tuple.from(deadLetteredTimeMillis, taskKeyB)),
+                    dlqTasks.pack(Tuple.from(
+                        deadLetteredTimeMillis,
+                        taskKeyB,
+                        taskClaim
+                            .taskProto()
+                            .getTaskUuid()
+                            .toByteArray())),
                     dlqEntry.toByteArray());
                 dlqAdded.add(1, Attributes.of(QUEUE_PATH, queuePath));
                 LOGGER.info(
@@ -1229,28 +1229,61 @@ public class KeyedTaskQueue<K, T> implements TaskQueue<K, T> {
   public CompletableFuture<Void> redriveFromDlq(Transaction tr, K taskKey) {
     ByteString taskKeyBytes = config.getKeySerializer().serialize(taskKey);
     byte[] taskKeyB = taskKeyBytes.toByteArray();
-    // DLQ entries are keyed by (timestamp, taskKeyBytes), so we need to scan to find the
-    // entry matching the given task key.
-    return tr.getRange(dlqTasks.range()).asList().thenCompose(kvs -> {
-      for (KeyValue kv : kvs) {
-        Tuple keyTuple = dlqTasks.unpack(kv.getKey());
-        byte[] entryTaskKeyB = keyTuple.getBytes(1);
-        if (java.util.Arrays.equals(entryTaskKeyB, taskKeyB)) {
-          DeadLetteredTask dlqEntry;
-          try {
-            dlqEntry = DeadLetteredTask.parseFrom(kv.getValue());
-          } catch (InvalidProtocolBufferException e) {
-            throw new TaskQueueException("Failed to parse DLQ entry", e);
-          }
-          // Re-enqueue the task with attempts=0 and immediate visibility.
-          T task = config.getTaskSerializer().deserialize(dlqEntry.getTask());
-          tr.clear(kv.getKey());
-          dlqRedriven.add(1, Attributes.of(QUEUE_PATH, queuePath));
-          return enqueue(tr, taskKey, task, Duration.ZERO, config.getDefaultTtl())
-              .thenApply(v -> null);
-        }
+    // DLQ entries are keyed by (timestamp, taskKeyBytes[, taskUuid]), so we need to scan to find the
+    // entry matching the given task key. Use an asynchronous iterator to avoid
+    // materializing the entire range into memory.
+    com.apple.foundationdb.async.AsyncIterator<KeyValue> iterator =
+        tr.getRange(dlqTasks.range()).iterator();
+    CompletableFuture<Void> resultFuture = new CompletableFuture<>();
+    redriveFromDlqScan(tr, taskKey, taskKeyB, iterator, resultFuture);
+    return resultFuture;
+  }
+
+  /**
+   * Helper method to iteratively scan the DLQ range for a matching task key and redrive it.
+   */
+  private void redriveFromDlqScan(
+      Transaction tr,
+      K taskKey,
+      byte[] taskKeyB,
+      com.apple.foundationdb.async.AsyncIterator<KeyValue> iterator,
+      CompletableFuture<Void> resultFuture) {
+    iterator.onHasNext().whenComplete((hasNext, error) -> {
+      if (error != null) {
+        resultFuture.completeExceptionally(error);
+        return;
       }
-      throw new TaskQueueException("No DLQ entry found for task key: " + taskKey);
+      if (!hasNext) {
+        resultFuture.completeExceptionally(
+            new TaskQueueException("No DLQ entry found for task key: " + taskKey));
+        return;
+      }
+      KeyValue kv = iterator.next();
+      Tuple keyTuple = dlqTasks.unpack(kv.getKey());
+      byte[] entryTaskKeyB = keyTuple.getBytes(1);
+      if (!java.util.Arrays.equals(entryTaskKeyB, taskKeyB)) {
+        // Not a match; continue scanning.
+        redriveFromDlqScan(tr, taskKey, taskKeyB, iterator, resultFuture);
+        return;
+      }
+      DeadLetteredTask dlqEntry;
+      try {
+        dlqEntry = DeadLetteredTask.parseFrom(kv.getValue());
+      } catch (InvalidProtocolBufferException e) {
+        resultFuture.completeExceptionally(new TaskQueueException("Failed to parse DLQ entry", e));
+        return;
+      }
+      // Re-enqueue the task with attempts=0 and immediate visibility.
+      T task = config.getTaskSerializer().deserialize(dlqEntry.getTask());
+      tr.clear(kv.getKey());
+      dlqRedriven.add(1, Attributes.of(QUEUE_PATH, queuePath));
+      enqueue(tr, taskKey, task, Duration.ZERO, config.getDefaultTtl()).whenComplete((v, enqueueError) -> {
+        if (enqueueError != null) {
+          resultFuture.completeExceptionally(enqueueError);
+        } else {
+          resultFuture.complete(null);
+        }
+      });
     });
   }
 

--- a/src/main/java/io/github/panghy/taskqueue/KeyedTaskQueue.java
+++ b/src/main/java/io/github/panghy/taskqueue/KeyedTaskQueue.java
@@ -1226,68 +1226,6 @@ public class KeyedTaskQueue<K, T> implements TaskQueue<K, T> {
   }
 
   @Override
-  public CompletableFuture<Void> redriveFromDlq(Transaction tr, K taskKey) {
-    ByteString taskKeyBytes = config.getKeySerializer().serialize(taskKey);
-    byte[] taskKeyB = taskKeyBytes.toByteArray();
-    // DLQ entries are keyed by (timestamp, taskKeyBytes[, taskUuid]), so we need to scan to find the
-    // entry matching the given task key. Use an asynchronous iterator to avoid
-    // materializing the entire range into memory.
-    com.apple.foundationdb.async.AsyncIterator<KeyValue> iterator =
-        tr.getRange(dlqTasks.range()).iterator();
-    CompletableFuture<Void> resultFuture = new CompletableFuture<>();
-    redriveFromDlqScan(tr, taskKey, taskKeyB, iterator, resultFuture);
-    return resultFuture;
-  }
-
-  /**
-   * Helper method to iteratively scan the DLQ range for a matching task key and redrive it.
-   */
-  private void redriveFromDlqScan(
-      Transaction tr,
-      K taskKey,
-      byte[] taskKeyB,
-      com.apple.foundationdb.async.AsyncIterator<KeyValue> iterator,
-      CompletableFuture<Void> resultFuture) {
-    iterator.onHasNext().whenComplete((hasNext, error) -> {
-      if (error != null) {
-        resultFuture.completeExceptionally(error);
-        return;
-      }
-      if (!hasNext) {
-        resultFuture.completeExceptionally(
-            new TaskQueueException("No DLQ entry found for task key: " + taskKey));
-        return;
-      }
-      KeyValue kv = iterator.next();
-      Tuple keyTuple = dlqTasks.unpack(kv.getKey());
-      byte[] entryTaskKeyB = keyTuple.getBytes(1);
-      if (!java.util.Arrays.equals(entryTaskKeyB, taskKeyB)) {
-        // Not a match; continue scanning.
-        redriveFromDlqScan(tr, taskKey, taskKeyB, iterator, resultFuture);
-        return;
-      }
-      DeadLetteredTask dlqEntry;
-      try {
-        dlqEntry = DeadLetteredTask.parseFrom(kv.getValue());
-      } catch (InvalidProtocolBufferException e) {
-        resultFuture.completeExceptionally(new TaskQueueException("Failed to parse DLQ entry", e));
-        return;
-      }
-      // Re-enqueue the task with attempts=0 and immediate visibility.
-      T task = config.getTaskSerializer().deserialize(dlqEntry.getTask());
-      tr.clear(kv.getKey());
-      dlqRedriven.add(1, Attributes.of(QUEUE_PATH, queuePath));
-      enqueue(tr, taskKey, task, Duration.ZERO, config.getDefaultTtl()).whenComplete((v, enqueueError) -> {
-        if (enqueueError != null) {
-          resultFuture.completeExceptionally(enqueueError);
-        } else {
-          resultFuture.complete(null);
-        }
-      });
-    });
-  }
-
-  @Override
   public CompletableFuture<Integer> redriveFromDlq(Transaction tr, int count) {
     if (count < 0) {
       throw new IllegalArgumentException("count must be non-negative, but was " + count);

--- a/src/main/java/io/github/panghy/taskqueue/KeyedTaskQueue.java
+++ b/src/main/java/io/github/panghy/taskqueue/KeyedTaskQueue.java
@@ -34,6 +34,7 @@ import io.opentelemetry.api.trace.Tracer;
 import java.security.SecureRandom;
 import java.time.Duration;
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -184,7 +185,11 @@ public class KeyedTaskQueue<K, T> implements TaskQueue<K, T> {
     }));
     return allOf(unclaimedTaskF, claimedTaskF, taskKeyF, dlqF, watchKeyF, watchKeyWriteF)
         .thenApply(v -> new KeyedTaskQueue<>(
-            config, unclaimedTaskF.join(), claimedTaskF.join(), taskKeyF.join(), dlqF.join(),
+            config,
+            unclaimedTaskF.join(),
+            claimedTaskF.join(),
+            taskKeyF.join(),
+            dlqF.join(),
             watchKeyF.join()));
   }
 
@@ -642,11 +647,30 @@ public class KeyedTaskQueue<K, T> implements TaskQueue<K, T> {
           if (taskClaim.taskProto().getTaskVersion() == taskMetadataProto.getHighestVersionSeen()) {
             // we are the latest version, fail the task.
             if (taskClaim.taskProto().getAttempts() >= config.getMaxAttempts()) {
-              // we have reached the max attempts, clear the task.
+              // we have reached the max attempts.
               LOGGER.warn(
-                  "Task {} has reached max attempts: {}. Skipping.",
+                  "Task {} has reached max attempts: {}.",
                   describeTask(taskUuid, taskClaim.task()),
                   taskClaim.taskProto().getAttempts());
+              if (config.isDlqEnabled()) {
+                // Move to dead letter queue.
+                DeadLetteredTask dlqEntry = DeadLetteredTask.newBuilder()
+                    .setTaskUuid(taskClaim.taskProto().getTaskUuid())
+                    .setTaskKey(taskKeyBytes)
+                    .setTask(taskClaim.taskKeyProto().getTask())
+                    .setCreationTime(taskClaim.taskProto().getCreationTime())
+                    .setDeadLetteredTime(fromJavaTimestamp(
+                        config.getInstantSource().instant()))
+                    .setFailureReason(failureReason != null ? failureReason : "")
+                    .setAttempts(taskClaim.taskProto().getAttempts())
+                    .build();
+                tr.set(dlqTasks.pack(Tuple.from(taskKeyB)), dlqEntry.toByteArray());
+                dlqAdded.add(1, Attributes.of(QUEUE_PATH, queuePath));
+                LOGGER.info(
+                    "Task {} moved to DLQ after {} attempts.",
+                    describeTask(taskUuid, taskClaim.task()),
+                    taskClaim.taskProto().getAttempts());
+              }
               // clear all versions of the task (+ metadata).
               tr.clear(Range.startsWith(taskKeys.pack(taskKeyB)));
             } else {
@@ -1197,26 +1221,85 @@ public class KeyedTaskQueue<K, T> implements TaskQueue<K, T> {
 
   @Override
   public CompletableFuture<Void> redriveFromDlq(Transaction tr, K taskKey) {
-    throw new UnsupportedOperationException("DLQ redrive not yet implemented");
+    ByteString taskKeyBytes = config.getKeySerializer().serialize(taskKey);
+    byte[] taskKeyB = taskKeyBytes.toByteArray();
+    byte[] dlqKey = dlqTasks.pack(Tuple.from(taskKeyB));
+    return tr.get(dlqKey).thenCompose(dlqValue -> {
+      if (dlqValue == null) {
+        throw new TaskQueueException("No DLQ entry found for task key: " + taskKey);
+      }
+      DeadLetteredTask dlqEntry;
+      try {
+        dlqEntry = DeadLetteredTask.parseFrom(dlqValue);
+      } catch (InvalidProtocolBufferException e) {
+        throw new TaskQueueException("Failed to parse DLQ entry", e);
+      }
+      // Re-enqueue the task with attempts=0 and immediate visibility.
+      T task = config.getTaskSerializer().deserialize(dlqEntry.getTask());
+      tr.clear(dlqKey);
+      dlqRedriven.add(1, Attributes.of(QUEUE_PATH, queuePath));
+      return enqueue(tr, taskKey, task, Duration.ZERO, config.getDefaultTtl())
+          .thenApply(v -> null);
+    });
   }
 
   @Override
   public CompletableFuture<Integer> redriveFromDlq(Transaction tr, int count) {
-    throw new UnsupportedOperationException("DLQ redrive not yet implemented");
+    return tr.getRange(dlqTasks.range(), count).asList().thenCompose(kvs -> {
+      int redriven = 0;
+      CompletableFuture<Void> chain = completedFuture(null);
+      for (KeyValue kv : kvs) {
+        DeadLetteredTask dlqEntry;
+        try {
+          dlqEntry = DeadLetteredTask.parseFrom(kv.getValue());
+        } catch (InvalidProtocolBufferException e) {
+          throw new TaskQueueException("Failed to parse DLQ entry", e);
+        }
+        K taskKey = config.getKeySerializer().deserialize(dlqEntry.getTaskKey());
+        T task = config.getTaskSerializer().deserialize(dlqEntry.getTask());
+        tr.clear(kv.getKey());
+        chain = chain.thenCompose(v -> enqueue(tr, taskKey, task, Duration.ZERO, config.getDefaultTtl())
+            .thenApply(m -> null));
+        redriven++;
+      }
+      int totalRedriven = redriven;
+      return chain.thenApply(v -> {
+        if (totalRedriven > 0) {
+          dlqRedriven.add(totalRedriven, Attributes.of(QUEUE_PATH, queuePath));
+        }
+        return totalRedriven;
+      });
+    });
   }
 
   @Override
   public CompletableFuture<Void> purgeDlq(Transaction tr) {
-    throw new UnsupportedOperationException("DLQ purge not yet implemented");
+    return getDlqSize(tr).thenApply(size -> {
+      tr.clear(dlqTasks.range());
+      if (size > 0) {
+        dlqPurged.add(size, Attributes.of(QUEUE_PATH, queuePath));
+      }
+      return null;
+    });
   }
 
   @Override
   public CompletableFuture<Long> getDlqSize(Transaction tr) {
-    throw new UnsupportedOperationException("DLQ size not yet implemented");
+    return tr.getRange(dlqTasks.range()).asList().thenApply(kvs -> (long) kvs.size());
   }
 
   @Override
   public CompletableFuture<List<DeadLetteredTask>> listDlqTasks(Transaction tr, int limit) {
-    throw new UnsupportedOperationException("DLQ list not yet implemented");
+    return tr.getRange(dlqTasks.range(), limit).asList().thenApply(kvs -> {
+      List<DeadLetteredTask> result = new ArrayList<>();
+      for (KeyValue kv : kvs) {
+        try {
+          result.add(DeadLetteredTask.parseFrom(kv.getValue()));
+        } catch (InvalidProtocolBufferException e) {
+          throw new TaskQueueException("Failed to parse DLQ entry", e);
+        }
+      }
+      return result;
+    });
   }
 }

--- a/src/main/java/io/github/panghy/taskqueue/KeyedTaskQueue.java
+++ b/src/main/java/io/github/panghy/taskqueue/KeyedTaskQueue.java
@@ -664,7 +664,11 @@ public class KeyedTaskQueue<K, T> implements TaskQueue<K, T> {
                     .setFailureReason(failureReason != null ? failureReason : "")
                     .setAttempts(taskClaim.taskProto().getAttempts())
                     .build();
-                tr.set(dlqTasks.pack(Tuple.from(taskKeyB)), dlqEntry.toByteArray());
+                long deadLetteredTimeMillis =
+                    config.getInstantSource().instant().toEpochMilli();
+                tr.set(
+                    dlqTasks.pack(Tuple.from(deadLetteredTimeMillis, taskKeyB)),
+                    dlqEntry.toByteArray());
                 dlqAdded.add(1, Attributes.of(QUEUE_PATH, queuePath));
                 LOGGER.info(
                     "Task {} moved to DLQ after {} attempts.",
@@ -673,6 +677,8 @@ public class KeyedTaskQueue<K, T> implements TaskQueue<K, T> {
               }
               // clear all versions of the task (+ metadata).
               tr.clear(Range.startsWith(taskKeys.pack(taskKeyB)));
+              // notify watchers that the queue has changed (and may now be empty).
+              incrementWatchKey(tr);
             } else {
               LOGGER.debug(
                   "Failing task: {} with {} attempts. Rescheduling for future execution.",
@@ -1223,28 +1229,39 @@ public class KeyedTaskQueue<K, T> implements TaskQueue<K, T> {
   public CompletableFuture<Void> redriveFromDlq(Transaction tr, K taskKey) {
     ByteString taskKeyBytes = config.getKeySerializer().serialize(taskKey);
     byte[] taskKeyB = taskKeyBytes.toByteArray();
-    byte[] dlqKey = dlqTasks.pack(Tuple.from(taskKeyB));
-    return tr.get(dlqKey).thenCompose(dlqValue -> {
-      if (dlqValue == null) {
-        throw new TaskQueueException("No DLQ entry found for task key: " + taskKey);
+    // DLQ entries are keyed by (timestamp, taskKeyBytes), so we need to scan to find the
+    // entry matching the given task key.
+    return tr.getRange(dlqTasks.range()).asList().thenCompose(kvs -> {
+      for (KeyValue kv : kvs) {
+        Tuple keyTuple = dlqTasks.unpack(kv.getKey());
+        byte[] entryTaskKeyB = keyTuple.getBytes(1);
+        if (java.util.Arrays.equals(entryTaskKeyB, taskKeyB)) {
+          DeadLetteredTask dlqEntry;
+          try {
+            dlqEntry = DeadLetteredTask.parseFrom(kv.getValue());
+          } catch (InvalidProtocolBufferException e) {
+            throw new TaskQueueException("Failed to parse DLQ entry", e);
+          }
+          // Re-enqueue the task with attempts=0 and immediate visibility.
+          T task = config.getTaskSerializer().deserialize(dlqEntry.getTask());
+          tr.clear(kv.getKey());
+          dlqRedriven.add(1, Attributes.of(QUEUE_PATH, queuePath));
+          return enqueue(tr, taskKey, task, Duration.ZERO, config.getDefaultTtl())
+              .thenApply(v -> null);
+        }
       }
-      DeadLetteredTask dlqEntry;
-      try {
-        dlqEntry = DeadLetteredTask.parseFrom(dlqValue);
-      } catch (InvalidProtocolBufferException e) {
-        throw new TaskQueueException("Failed to parse DLQ entry", e);
-      }
-      // Re-enqueue the task with attempts=0 and immediate visibility.
-      T task = config.getTaskSerializer().deserialize(dlqEntry.getTask());
-      tr.clear(dlqKey);
-      dlqRedriven.add(1, Attributes.of(QUEUE_PATH, queuePath));
-      return enqueue(tr, taskKey, task, Duration.ZERO, config.getDefaultTtl())
-          .thenApply(v -> null);
+      throw new TaskQueueException("No DLQ entry found for task key: " + taskKey);
     });
   }
 
   @Override
   public CompletableFuture<Integer> redriveFromDlq(Transaction tr, int count) {
+    if (count < 0) {
+      throw new IllegalArgumentException("count must be non-negative, but was " + count);
+    }
+    if (count == 0) {
+      return completedFuture(0);
+    }
     return tr.getRange(dlqTasks.range(), count).asList().thenCompose(kvs -> {
       int redriven = 0;
       CompletableFuture<Void> chain = completedFuture(null);
@@ -1274,22 +1291,26 @@ public class KeyedTaskQueue<K, T> implements TaskQueue<K, T> {
 
   @Override
   public CompletableFuture<Void> purgeDlq(Transaction tr) {
-    return getDlqSize(tr).thenApply(size -> {
-      tr.clear(dlqTasks.range());
-      if (size > 0) {
-        dlqPurged.add(size, Attributes.of(QUEUE_PATH, queuePath));
-      }
-      return null;
-    });
+    tr.clear(dlqTasks.range());
+    // Note: we intentionally skip counting DLQ entries before purging to avoid
+    // scanning the entire DLQ, which can be expensive for large queues and risk
+    // transaction size/time limits.
+    return completedFuture(null);
   }
 
   @Override
   public CompletableFuture<Long> getDlqSize(Transaction tr) {
+    // Note: this reads the entire DLQ range into memory. For very large DLQs,
+    // this may be slow and risk transaction size limits. A stored counter could
+    // be used instead if this becomes a bottleneck.
     return tr.getRange(dlqTasks.range()).asList().thenApply(kvs -> (long) kvs.size());
   }
 
   @Override
   public CompletableFuture<List<DeadLetteredTask>> listDlqTasks(Transaction tr, int limit) {
+    if (limit < 0) {
+      throw new IllegalArgumentException("limit must be non-negative, but was " + limit);
+    }
     return tr.getRange(dlqTasks.range(), limit).asList().thenApply(kvs -> {
       List<DeadLetteredTask> result = new ArrayList<>();
       for (KeyValue kv : kvs) {

--- a/src/main/java/io/github/panghy/taskqueue/SimpleTaskQueue.java
+++ b/src/main/java/io/github/panghy/taskqueue/SimpleTaskQueue.java
@@ -2,8 +2,10 @@ package io.github.panghy.taskqueue;
 
 import com.apple.foundationdb.Database;
 import com.apple.foundationdb.Transaction;
+import io.github.panghy.taskqueue.proto.DeadLetteredTask;
 import io.github.panghy.taskqueue.proto.TaskKeyMetadata;
 import java.time.Duration;
+import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
@@ -118,22 +120,49 @@ public interface SimpleTaskQueue<T> {
 
   /**
    * Fails the task. This will cause the task to be retried at the current known highest version.
+   * Uses a standalone transaction.
    *
    * @param taskClaim The task claim.
    * @return A future that completes when the task has been failed.
    */
   default CompletableFuture<Void> failTask(TaskClaim<UUID, T> taskClaim) {
-    return runAsync(tr -> failTask(tr, taskClaim));
+    return runAsync(tr -> failTask(tr, taskClaim, null));
   }
 
   /**
-   * Fails the task. This will cause the task to be retried at the current known highest version.
+   * Fails the task with a failure reason. This will cause the task to be retried at the current known highest version.
+   * Uses a standalone transaction.
+   *
+   * @param taskClaim     The task claim.
+   * @param failureReason The reason for the failure (may be null).
+   * @return A future that completes when the task has been failed.
+   */
+  default CompletableFuture<Void> failTask(TaskClaim<UUID, T> taskClaim, String failureReason) {
+    return runAsync(tr -> failTask(tr, taskClaim, failureReason));
+  }
+
+  /**
+   * Fails the task within an existing transaction. This will cause the task to be retried at the current known
+   * highest version.
    *
    * @param tr        The transaction to use for the operation.
    * @param taskClaim The task claim.
    * @return A future that completes when the task has been failed.
    */
-  CompletableFuture<Void> failTask(Transaction tr, TaskClaim<UUID, T> taskClaim);
+  default CompletableFuture<Void> failTask(Transaction tr, TaskClaim<UUID, T> taskClaim) {
+    return failTask(tr, taskClaim, null);
+  }
+
+  /**
+   * Fails the task within an existing transaction with a failure reason. This will cause the task to be retried
+   * at the current known highest version.
+   *
+   * @param tr            The transaction to use for the operation.
+   * @param taskClaim     The task claim.
+   * @param failureReason The reason for the failure (may be null).
+   * @return A future that completes when the task has been failed.
+   */
+  CompletableFuture<Void> failTask(Transaction tr, TaskClaim<UUID, T> taskClaim, String failureReason);
 
   /**
    * Extends the TTL for a claimed task. This allows a worker to request more time to process a task.
@@ -238,4 +267,102 @@ public interface SimpleTaskQueue<T> {
    * @return A future that completes when the queue is empty.
    */
   CompletableFuture<Void> awaitQueueEmpty(Database db);
+
+  // ---- Dead Letter Queue (DLQ) methods ----
+
+  /**
+   * Redrives a specific task from the dead letter queue back to the main queue by task key.
+   * Uses a standalone transaction.
+   *
+   * @param taskKey The key of the task to redrive.
+   * @return A future that completes when the task has been redriven.
+   */
+  default CompletableFuture<Void> redriveFromDlq(UUID taskKey) {
+    return runAsync(tr -> redriveFromDlq(tr, taskKey));
+  }
+
+  /**
+   * Redrives a specific task from the dead letter queue back to the main queue by task key.
+   *
+   * @param tr      The transaction to use for the operation.
+   * @param taskKey The key of the task to redrive.
+   * @return A future that completes when the task has been redriven.
+   */
+  CompletableFuture<Void> redriveFromDlq(Transaction tr, UUID taskKey);
+
+  /**
+   * Redrives up to {@code count} tasks from the dead letter queue back to the main queue.
+   * Uses a standalone transaction.
+   *
+   * @param count The maximum number of tasks to redrive.
+   * @return A future that completes with the number of tasks actually redriven.
+   */
+  default CompletableFuture<Integer> redriveFromDlq(int count) {
+    return runAsync(tr -> redriveFromDlq(tr, count));
+  }
+
+  /**
+   * Redrives up to {@code count} tasks from the dead letter queue back to the main queue.
+   *
+   * @param tr    The transaction to use for the operation.
+   * @param count The maximum number of tasks to redrive.
+   * @return A future that completes with the number of tasks actually redriven.
+   */
+  CompletableFuture<Integer> redriveFromDlq(Transaction tr, int count);
+
+  /**
+   * Purges all tasks from the dead letter queue.
+   * Uses a standalone transaction.
+   *
+   * @return A future that completes when the DLQ has been purged.
+   */
+  default CompletableFuture<Void> purgeDlq() {
+    return runAsync(this::purgeDlq);
+  }
+
+  /**
+   * Purges all tasks from the dead letter queue.
+   *
+   * @param tr The transaction to use for the operation.
+   * @return A future that completes when the DLQ has been purged.
+   */
+  CompletableFuture<Void> purgeDlq(Transaction tr);
+
+  /**
+   * Gets the number of tasks in the dead letter queue.
+   * Uses a standalone transaction.
+   *
+   * @return A future that completes with the number of tasks in the DLQ.
+   */
+  default CompletableFuture<Long> getDlqSize() {
+    return runAsync(this::getDlqSize);
+  }
+
+  /**
+   * Gets the number of tasks in the dead letter queue.
+   *
+   * @param tr The transaction to use for the operation.
+   * @return A future that completes with the number of tasks in the DLQ.
+   */
+  CompletableFuture<Long> getDlqSize(Transaction tr);
+
+  /**
+   * Lists tasks in the dead letter queue, ordered oldest first.
+   * Uses a standalone transaction.
+   *
+   * @param limit The maximum number of tasks to return.
+   * @return A future that completes with a list of dead-lettered tasks.
+   */
+  default CompletableFuture<List<DeadLetteredTask>> listDlqTasks(int limit) {
+    return runAsync(tr -> listDlqTasks(tr, limit));
+  }
+
+  /**
+   * Lists tasks in the dead letter queue, ordered oldest first.
+   *
+   * @param tr    The transaction to use for the operation.
+   * @param limit The maximum number of tasks to return.
+   * @return A future that completes with a list of dead-lettered tasks.
+   */
+  CompletableFuture<List<DeadLetteredTask>> listDlqTasks(Transaction tr, int limit);
 }

--- a/src/main/java/io/github/panghy/taskqueue/SimpleTaskQueue.java
+++ b/src/main/java/io/github/panghy/taskqueue/SimpleTaskQueue.java
@@ -271,34 +271,26 @@ public interface SimpleTaskQueue<T> {
   // ---- Dead Letter Queue (DLQ) methods ----
 
   /**
-   * Redrives a specific task from the dead letter queue back to the main queue by task key.
-   * Uses a standalone transaction.
-   *
-   * @param taskKey The key of the task to redrive.
-   * @return A future that completes when the task has been redriven.
-   */
-  default CompletableFuture<Void> redriveFromDlq(UUID taskKey) {
-    return runAsync(tr -> redriveFromDlq(tr, taskKey));
-  }
-
-  /**
-   * Redrives a specific task from the dead letter queue back to the main queue by task key.
-   *
-   * @param tr      The transaction to use for the operation.
-   * @param taskKey The key of the task to redrive.
-   * @return A future that completes when the task has been redriven.
-   */
-  CompletableFuture<Void> redriveFromDlq(Transaction tr, UUID taskKey);
-
-  /**
    * Redrives up to {@code count} tasks from the dead letter queue back to the main queue.
-   * Uses a standalone transaction.
+   * Uses multiple standalone transactions, each processing up to {@code dlqRedriveBatchSize} tasks,
+   * to avoid exceeding FoundationDB transaction limits for large redrives.
    *
    * @param count The maximum number of tasks to redrive.
    * @return A future that completes with the number of tasks actually redriven.
    */
   default CompletableFuture<Integer> redriveFromDlq(int count) {
-    return runAsync(tr -> redriveFromDlq(tr, count));
+    int batchSize = getConfig().getDlqRedriveBatchSize();
+    java.util.concurrent.atomic.AtomicInteger totalRedriven = new java.util.concurrent.atomic.AtomicInteger(0);
+    java.util.concurrent.atomic.AtomicInteger remaining = new java.util.concurrent.atomic.AtomicInteger(count);
+    return com.apple.foundationdb.async.AsyncUtil.whileTrue(() -> {
+          int thisBatch = Math.min(remaining.get(), batchSize);
+          return runAsync(tr -> redriveFromDlq(tr, thisBatch)).thenApply(redriven -> {
+            totalRedriven.addAndGet(redriven);
+            remaining.addAndGet(-redriven);
+            return redriven > 0 && remaining.get() > 0;
+          });
+        })
+        .thenApply(v -> totalRedriven.get());
   }
 
   /**

--- a/src/main/java/io/github/panghy/taskqueue/SimpleTaskQueueWrapper.java
+++ b/src/main/java/io/github/panghy/taskqueue/SimpleTaskQueueWrapper.java
@@ -80,11 +80,6 @@ public class SimpleTaskQueueWrapper<T> implements SimpleTaskQueue<T> {
   }
 
   @Override
-  public CompletableFuture<Void> redriveFromDlq(Transaction tr, UUID taskKey) {
-    return taskQueue.redriveFromDlq(tr, taskKey);
-  }
-
-  @Override
   public CompletableFuture<Integer> redriveFromDlq(Transaction tr, int count) {
     return taskQueue.redriveFromDlq(tr, count);
   }

--- a/src/main/java/io/github/panghy/taskqueue/SimpleTaskQueueWrapper.java
+++ b/src/main/java/io/github/panghy/taskqueue/SimpleTaskQueueWrapper.java
@@ -3,8 +3,10 @@ package io.github.panghy.taskqueue;
 import com.apple.foundationdb.Database;
 import com.apple.foundationdb.Transaction;
 import com.apple.foundationdb.TransactionContext;
+import io.github.panghy.taskqueue.proto.DeadLetteredTask;
 import io.github.panghy.taskqueue.proto.TaskKeyMetadata;
 import java.time.Duration;
+import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 
@@ -48,8 +50,8 @@ public class SimpleTaskQueueWrapper<T> implements SimpleTaskQueue<T> {
   }
 
   @Override
-  public CompletableFuture<Void> failTask(Transaction tr, TaskClaim<UUID, T> taskClaim) {
-    return taskQueue.failTask(tr, taskClaim);
+  public CompletableFuture<Void> failTask(Transaction tr, TaskClaim<UUID, T> taskClaim, String failureReason) {
+    return taskQueue.failTask(tr, taskClaim, failureReason);
   }
 
   @Override
@@ -75,5 +77,30 @@ public class SimpleTaskQueueWrapper<T> implements SimpleTaskQueue<T> {
   @Override
   public CompletableFuture<Void> awaitQueueEmpty(Database db) {
     return taskQueue.awaitQueueEmpty(db);
+  }
+
+  @Override
+  public CompletableFuture<Void> redriveFromDlq(Transaction tr, UUID taskKey) {
+    return taskQueue.redriveFromDlq(tr, taskKey);
+  }
+
+  @Override
+  public CompletableFuture<Integer> redriveFromDlq(Transaction tr, int count) {
+    return taskQueue.redriveFromDlq(tr, count);
+  }
+
+  @Override
+  public CompletableFuture<Void> purgeDlq(Transaction tr) {
+    return taskQueue.purgeDlq(tr);
+  }
+
+  @Override
+  public CompletableFuture<Long> getDlqSize(Transaction tr) {
+    return taskQueue.getDlqSize(tr);
+  }
+
+  @Override
+  public CompletableFuture<List<DeadLetteredTask>> listDlqTasks(Transaction tr, int limit) {
+    return taskQueue.listDlqTasks(tr, limit);
   }
 }

--- a/src/main/java/io/github/panghy/taskqueue/TaskClaim.java
+++ b/src/main/java/io/github/panghy/taskqueue/TaskClaim.java
@@ -52,7 +52,7 @@ public record TaskClaim<K, T>(
    * @return A future that completes when the task has been failed.
    */
   public CompletableFuture<Void> fail() {
-    return taskQueue.failTask(this);
+    return taskQueue.failTask(this, null);
   }
 
   /**
@@ -62,7 +62,29 @@ public record TaskClaim<K, T>(
    * @return A future that completes when the task has been failed.
    */
   public CompletableFuture<Void> fail(Transaction tr) {
-    return taskQueue.failTask(tr, this);
+    return taskQueue.failTask(tr, this, null);
+  }
+
+  /**
+   * Fails the task with a failure reason, causing it to be retried.
+   * Uses a standalone transaction.
+   *
+   * @param failureReason the reason for the failure (may be null)
+   * @return A future that completes when the task has been failed.
+   */
+  public CompletableFuture<Void> fail(String failureReason) {
+    return taskQueue.failTask(this, failureReason);
+  }
+
+  /**
+   * Fails the task within an existing transaction with a failure reason.
+   *
+   * @param tr            the transaction to use
+   * @param failureReason the reason for the failure (may be null)
+   * @return A future that completes when the task has been failed.
+   */
+  public CompletableFuture<Void> fail(Transaction tr, String failureReason) {
+    return taskQueue.failTask(tr, this, failureReason);
   }
 
   /**

--- a/src/main/java/io/github/panghy/taskqueue/TaskQueue.java
+++ b/src/main/java/io/github/panghy/taskqueue/TaskQueue.java
@@ -357,34 +357,26 @@ public interface TaskQueue<K, T> {
   // ---- Dead Letter Queue (DLQ) methods ----
 
   /**
-   * Redrives a specific task from the dead letter queue back to the main queue by task key.
-   * Uses a standalone transaction.
-   *
-   * @param taskKey The key of the task to redrive.
-   * @return A future that completes when the task has been redriven.
-   */
-  default CompletableFuture<Void> redriveFromDlq(K taskKey) {
-    return runAsync(tr -> redriveFromDlq(tr, taskKey));
-  }
-
-  /**
-   * Redrives a specific task from the dead letter queue back to the main queue by task key.
-   *
-   * @param tr      The transaction to use for the operation.
-   * @param taskKey The key of the task to redrive.
-   * @return A future that completes when the task has been redriven.
-   */
-  CompletableFuture<Void> redriveFromDlq(Transaction tr, K taskKey);
-
-  /**
    * Redrives up to {@code count} tasks from the dead letter queue back to the main queue.
-   * Uses a standalone transaction.
+   * Uses multiple standalone transactions, each processing up to {@code dlqRedriveBatchSize} tasks,
+   * to avoid exceeding FoundationDB transaction limits for large redrives.
    *
    * @param count The maximum number of tasks to redrive.
    * @return A future that completes with the number of tasks actually redriven.
    */
   default CompletableFuture<Integer> redriveFromDlq(int count) {
-    return runAsync(tr -> redriveFromDlq(tr, count));
+    int batchSize = getConfig().getDlqRedriveBatchSize();
+    java.util.concurrent.atomic.AtomicInteger totalRedriven = new java.util.concurrent.atomic.AtomicInteger(0);
+    java.util.concurrent.atomic.AtomicInteger remaining = new java.util.concurrent.atomic.AtomicInteger(count);
+    return com.apple.foundationdb.async.AsyncUtil.whileTrue(() -> {
+          int thisBatch = Math.min(remaining.get(), batchSize);
+          return runAsync(tr -> redriveFromDlq(tr, thisBatch)).thenApply(redriven -> {
+            totalRedriven.addAndGet(redriven);
+            remaining.addAndGet(-redriven);
+            return redriven > 0 && remaining.get() > 0;
+          });
+        })
+        .thenApply(v -> totalRedriven.get());
   }
 
   /**

--- a/src/main/java/io/github/panghy/taskqueue/TaskQueue.java
+++ b/src/main/java/io/github/panghy/taskqueue/TaskQueue.java
@@ -2,8 +2,10 @@ package io.github.panghy.taskqueue;
 
 import com.apple.foundationdb.Database;
 import com.apple.foundationdb.Transaction;
+import io.github.panghy.taskqueue.proto.DeadLetteredTask;
 import io.github.panghy.taskqueue.proto.TaskKeyMetadata;
 import java.time.Duration;
+import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
 
@@ -204,22 +206,49 @@ public interface TaskQueue<K, T> {
 
   /**
    * Fails the task. This will cause the task to be retried at the current known highest version.
+   * Uses a standalone transaction.
    *
    * @param taskClaim The task claim.
    * @return A future that completes when the task has been failed.
    */
   default CompletableFuture<Void> failTask(TaskClaim<K, T> taskClaim) {
-    return runAsync(tr -> failTask(tr, taskClaim));
+    return runAsync(tr -> failTask(tr, taskClaim, null));
   }
 
   /**
-   * Fails the task. This will cause the task to be retried at the current known highest version.
+   * Fails the task with a failure reason. This will cause the task to be retried at the current known highest version.
+   * Uses a standalone transaction.
+   *
+   * @param taskClaim     The task claim.
+   * @param failureReason The reason for the failure (may be null).
+   * @return A future that completes when the task has been failed.
+   */
+  default CompletableFuture<Void> failTask(TaskClaim<K, T> taskClaim, String failureReason) {
+    return runAsync(tr -> failTask(tr, taskClaim, failureReason));
+  }
+
+  /**
+   * Fails the task within an existing transaction. This will cause the task to be retried at the current known
+   * highest version.
    *
    * @param tr        The transaction to use for the operation.
    * @param taskClaim The task claim.
    * @return A future that completes when the task has been failed.
    */
-  CompletableFuture<Void> failTask(Transaction tr, TaskClaim<K, T> taskClaim);
+  default CompletableFuture<Void> failTask(Transaction tr, TaskClaim<K, T> taskClaim) {
+    return failTask(tr, taskClaim, null);
+  }
+
+  /**
+   * Fails the task within an existing transaction with a failure reason. This will cause the task to be retried
+   * at the current known highest version.
+   *
+   * @param tr            The transaction to use for the operation.
+   * @param taskClaim     The task claim.
+   * @param failureReason The reason for the failure (may be null).
+   * @return A future that completes when the task has been failed.
+   */
+  CompletableFuture<Void> failTask(Transaction tr, TaskClaim<K, T> taskClaim, String failureReason);
 
   /**
    * Extends the TTL for a claimed task. This allows a worker to request more time to process a task.
@@ -324,4 +353,102 @@ public interface TaskQueue<K, T> {
    * @return A future that completes when the queue is empty.
    */
   CompletableFuture<Void> awaitQueueEmpty(Database db);
+
+  // ---- Dead Letter Queue (DLQ) methods ----
+
+  /**
+   * Redrives a specific task from the dead letter queue back to the main queue by task key.
+   * Uses a standalone transaction.
+   *
+   * @param taskKey The key of the task to redrive.
+   * @return A future that completes when the task has been redriven.
+   */
+  default CompletableFuture<Void> redriveFromDlq(K taskKey) {
+    return runAsync(tr -> redriveFromDlq(tr, taskKey));
+  }
+
+  /**
+   * Redrives a specific task from the dead letter queue back to the main queue by task key.
+   *
+   * @param tr      The transaction to use for the operation.
+   * @param taskKey The key of the task to redrive.
+   * @return A future that completes when the task has been redriven.
+   */
+  CompletableFuture<Void> redriveFromDlq(Transaction tr, K taskKey);
+
+  /**
+   * Redrives up to {@code count} tasks from the dead letter queue back to the main queue.
+   * Uses a standalone transaction.
+   *
+   * @param count The maximum number of tasks to redrive.
+   * @return A future that completes with the number of tasks actually redriven.
+   */
+  default CompletableFuture<Integer> redriveFromDlq(int count) {
+    return runAsync(tr -> redriveFromDlq(tr, count));
+  }
+
+  /**
+   * Redrives up to {@code count} tasks from the dead letter queue back to the main queue.
+   *
+   * @param tr    The transaction to use for the operation.
+   * @param count The maximum number of tasks to redrive.
+   * @return A future that completes with the number of tasks actually redriven.
+   */
+  CompletableFuture<Integer> redriveFromDlq(Transaction tr, int count);
+
+  /**
+   * Purges all tasks from the dead letter queue.
+   * Uses a standalone transaction.
+   *
+   * @return A future that completes when the DLQ has been purged.
+   */
+  default CompletableFuture<Void> purgeDlq() {
+    return runAsync(this::purgeDlq);
+  }
+
+  /**
+   * Purges all tasks from the dead letter queue.
+   *
+   * @param tr The transaction to use for the operation.
+   * @return A future that completes when the DLQ has been purged.
+   */
+  CompletableFuture<Void> purgeDlq(Transaction tr);
+
+  /**
+   * Gets the number of tasks in the dead letter queue.
+   * Uses a standalone transaction.
+   *
+   * @return A future that completes with the number of tasks in the DLQ.
+   */
+  default CompletableFuture<Long> getDlqSize() {
+    return runAsync(this::getDlqSize);
+  }
+
+  /**
+   * Gets the number of tasks in the dead letter queue.
+   *
+   * @param tr The transaction to use for the operation.
+   * @return A future that completes with the number of tasks in the DLQ.
+   */
+  CompletableFuture<Long> getDlqSize(Transaction tr);
+
+  /**
+   * Lists tasks in the dead letter queue, ordered oldest first.
+   * Uses a standalone transaction.
+   *
+   * @param limit The maximum number of tasks to return.
+   * @return A future that completes with a list of dead-lettered tasks.
+   */
+  default CompletableFuture<List<DeadLetteredTask>> listDlqTasks(int limit) {
+    return runAsync(tr -> listDlqTasks(tr, limit));
+  }
+
+  /**
+   * Lists tasks in the dead letter queue, ordered oldest first.
+   *
+   * @param tr    The transaction to use for the operation.
+   * @param limit The maximum number of tasks to return.
+   * @return A future that completes with a list of dead-lettered tasks.
+   */
+  CompletableFuture<List<DeadLetteredTask>> listDlqTasks(Transaction tr, int limit);
 }

--- a/src/main/java/io/github/panghy/taskqueue/TaskQueueConfig.java
+++ b/src/main/java/io/github/panghy/taskqueue/TaskQueueConfig.java
@@ -98,6 +98,15 @@ public class TaskQueueConfig<K, T> {
   @Getter
   private final boolean dlqEnabled;
 
+  /**
+   * -- GETTER --
+   * Gets the batch size used for multi-transaction DLQ redrive operations.
+   * Each batch is processed in a separate transaction to avoid exceeding
+   * FoundationDB transaction limits.
+   */
+  @Getter
+  private final int dlqRedriveBatchSize;
+
   private TaskQueueConfig(Builder<K, T> builder) {
     this.database = Objects.requireNonNull(builder.database, "database must not be null");
     this.directory = Objects.requireNonNull(builder.directory, "subspace must not be null");
@@ -111,6 +120,7 @@ public class TaskQueueConfig<K, T> {
     this.estimatedWorkerCount = builder.estimatedWorkerCount;
     this.instantSource = Objects.requireNonNull(builder.instantSource, "instantSource must not be null");
     this.dlqEnabled = builder.dlqEnabled;
+    this.dlqRedriveBatchSize = builder.dlqRedriveBatchSize;
 
     if (maxAttempts <= 0) {
       throw new IllegalArgumentException("maxAttempts must be positive");
@@ -123,6 +133,9 @@ public class TaskQueueConfig<K, T> {
     }
     if (estimatedWorkerCount <= 0) {
       throw new IllegalArgumentException("estimatedWorkerCount must be positive");
+    }
+    if (dlqRedriveBatchSize <= 0) {
+      throw new IllegalArgumentException("dlqRedriveBatchSize must be positive");
     }
   }
 
@@ -188,6 +201,7 @@ public class TaskQueueConfig<K, T> {
     private TaskSerializer<K> keySerializer;
     private TaskSerializer<T> taskSerializer;
     private boolean dlqEnabled = false;
+    private int dlqRedriveBatchSize = 100;
 
     private Builder(
         Database database,
@@ -283,6 +297,15 @@ public class TaskQueueConfig<K, T> {
      */
     public Builder<K, T> dlqEnabled(boolean dlqEnabled) {
       this.dlqEnabled = dlqEnabled;
+      return this;
+    }
+
+    /**
+     * Sets the batch size for multi-transaction DLQ redrive operations.
+     * Default: 100
+     */
+    public Builder<K, T> dlqRedriveBatchSize(int dlqRedriveBatchSize) {
+      this.dlqRedriveBatchSize = dlqRedriveBatchSize;
       return this;
     }
 

--- a/src/main/java/io/github/panghy/taskqueue/TaskQueueConfig.java
+++ b/src/main/java/io/github/panghy/taskqueue/TaskQueueConfig.java
@@ -89,6 +89,15 @@ public class TaskQueueConfig<K, T> {
   @Getter
   private final InstantSource instantSource;
 
+  /**
+   * -- GETTER --
+   * Gets whether the dead letter queue is enabled for this task queue.
+   * When enabled, tasks that exceed maxAttempts will be moved to a DLQ
+   * instead of being discarded.
+   */
+  @Getter
+  private final boolean dlqEnabled;
+
   private TaskQueueConfig(Builder<K, T> builder) {
     this.database = Objects.requireNonNull(builder.database, "database must not be null");
     this.directory = Objects.requireNonNull(builder.directory, "subspace must not be null");
@@ -101,6 +110,7 @@ public class TaskQueueConfig<K, T> {
         Objects.requireNonNull(builder.taskNameExtractor, "taskNameExtractor must not be null");
     this.estimatedWorkerCount = builder.estimatedWorkerCount;
     this.instantSource = Objects.requireNonNull(builder.instantSource, "instantSource must not be null");
+    this.dlqEnabled = builder.dlqEnabled;
 
     if (maxAttempts <= 0) {
       throw new IllegalArgumentException("maxAttempts must be positive");
@@ -177,6 +187,7 @@ public class TaskQueueConfig<K, T> {
     private Duration defaultThrottle = Duration.ofSeconds(1);
     private TaskSerializer<K> keySerializer;
     private TaskSerializer<T> taskSerializer;
+    private boolean dlqEnabled = false;
 
     private Builder(
         Database database,
@@ -262,6 +273,16 @@ public class TaskQueueConfig<K, T> {
      */
     public Builder<K, T> taskSerializer(TaskSerializer<T> taskSerializer) {
       this.taskSerializer = taskSerializer;
+      return this;
+    }
+
+    /**
+     * Sets whether the dead letter queue is enabled.
+     * When enabled, tasks that exceed maxAttempts will be moved to a DLQ.
+     * Default: false
+     */
+    public Builder<K, T> dlqEnabled(boolean dlqEnabled) {
+      this.dlqEnabled = dlqEnabled;
       return this;
     }
 

--- a/src/main/proto/task.proto
+++ b/src/main/proto/task.proto
@@ -85,3 +85,28 @@ message TaskKeyMetadata {
   // Current claim for the task key
   optional CurrentClaim current_claim = 2;
 }
+
+// DeadLetteredTask represents a task that has been moved to the dead letter queue
+// after exhausting all retry attempts.
+message DeadLetteredTask {
+  // Unique identifier of the original task (UUID stored as 16 bytes)
+  bytes task_uuid = 1;
+
+  // The task key bytes
+  bytes task_key = 2;
+
+  // The task payload
+  bytes task = 3;
+
+  // When the task was originally created
+  google.protobuf.Timestamp creation_time = 4;
+
+  // When the task was moved to the dead letter queue
+  google.protobuf.Timestamp dead_lettered_time = 5;
+
+  // Last known failure reason
+  string failure_reason = 6;
+
+  // Number of attempts before dead-lettering
+  int64 attempts = 7;
+}

--- a/src/test/java/io/github/panghy/taskqueue/KeyedTaskQueueTest.java
+++ b/src/test/java/io/github/panghy/taskqueue/KeyedTaskQueueTest.java
@@ -2093,21 +2093,26 @@ public class KeyedTaskQueueTest {
         .build();
     var queue = KeyedTaskQueue.createOrOpen(dlqConfig, db).get();
 
-    queue.enqueue("redrive-key", "redrive-data").get(5, TimeUnit.SECONDS);
+    // Add two tasks to DLQ so the async iterator must scan past the first entry
+    queue.enqueue("redrive-key-1", "redrive-data-1").get(5, TimeUnit.SECONDS);
+    var claim1 = queue.awaitAndClaimTask(db).get(5, TimeUnit.SECONDS);
+    claim1.fail("test failure 1").get(5, TimeUnit.SECONDS);
 
-    var claim = queue.awaitAndClaimTask(db).get(5, TimeUnit.SECONDS);
-    claim.fail("test failure").get(5, TimeUnit.SECONDS);
+    simulatedTime.addAndGet(1000);
+    queue.enqueue("redrive-key-2", "redrive-data-2").get(5, TimeUnit.SECONDS);
+    var claim2 = queue.awaitAndClaimTask(db).get(5, TimeUnit.SECONDS);
+    claim2.fail("test failure 2").get(5, TimeUnit.SECONDS);
+
+    assertThat(queue.getDlqSize().get(5, TimeUnit.SECONDS)).isEqualTo(2);
+
+    // Redrive the second key (iterator must skip past the first entry)
+    queue.redriveFromDlq("redrive-key-2").get(5, TimeUnit.SECONDS);
 
     assertThat(queue.getDlqSize().get(5, TimeUnit.SECONDS)).isEqualTo(1);
 
-    // Redrive by key
-    queue.redriveFromDlq("redrive-key").get(5, TimeUnit.SECONDS);
-
-    assertThat(queue.getDlqSize().get(5, TimeUnit.SECONDS)).isEqualTo(0);
-
     // Task should be immediately claimable with attempts representing the first attempt after redrive
     var redriven = queue.awaitAndClaimTask(db).get(5, TimeUnit.SECONDS);
-    assertThat(redriven.task()).isEqualTo("redrive-data");
+    assertThat(redriven.task()).isEqualTo("redrive-data-2");
     assertThat(redriven.taskProto().getAttempts())
         .isEqualTo(1); // first attempt after redrive (counter reset on enqueue, incremented on claim)
     redriven.complete().get(5, TimeUnit.SECONDS);
@@ -2210,8 +2215,9 @@ public class KeyedTaskQueueTest {
         .build();
     var queue = KeyedTaskQueue.createOrOpen(dlqConfig, db).get();
 
-    // Add 3 tasks to DLQ
+    // Add 3 tasks to DLQ with advancing time between each failure
     for (int i = 1; i <= 3; i++) {
+      simulatedTime.addAndGet(1000); // Advance time by 1 second between failures
       queue.enqueue("list-key-" + i, "list-data-" + i).get(5, TimeUnit.SECONDS);
       var claim = queue.awaitAndClaimTask(db).get(5, TimeUnit.SECONDS);
       claim.fail("failure-" + i).get(5, TimeUnit.SECONDS);
@@ -2220,6 +2226,13 @@ public class KeyedTaskQueueTest {
     // List all
     List<DeadLetteredTask> allTasks = queue.listDlqTasks(10).get(5, TimeUnit.SECONDS);
     assertThat(allTasks).hasSize(3);
+
+    // Assert oldest-first ordering by dead_lettered_time
+    for (int i = 0; i < allTasks.size() - 1; i++) {
+      long t1 = allTasks.get(i).getDeadLetteredTime().getSeconds();
+      long t2 = allTasks.get(i + 1).getDeadLetteredTime().getSeconds();
+      assertThat(t1).isLessThan(t2);
+    }
 
     // List with limit
     List<DeadLetteredTask> limitedTasks = queue.listDlqTasks(2).get(5, TimeUnit.SECONDS);

--- a/src/test/java/io/github/panghy/taskqueue/KeyedTaskQueueTest.java
+++ b/src/test/java/io/github/panghy/taskqueue/KeyedTaskQueueTest.java
@@ -2008,7 +2008,7 @@ public class KeyedTaskQueueTest {
     // First attempt - fail
     var claim1 = queue.awaitAndClaimTask(db).get(5, TimeUnit.SECONDS);
     assertThat(claim1.taskProto().getAttempts()).isEqualTo(1);
-    claim1.fail();
+    claim1.fail().get(5, TimeUnit.SECONDS);
 
     // Second attempt - fail again (max attempts reached)
     var claim2 = queue.awaitAndClaimTask(db).get(5, TimeUnit.SECONDS);
@@ -2033,7 +2033,7 @@ public class KeyedTaskQueueTest {
 
     // First attempt - fail
     var claim1 = queue.awaitAndClaimTask(db).get(5, TimeUnit.SECONDS);
-    claim1.fail();
+    claim1.fail().get(5, TimeUnit.SECONDS);
 
     // Second attempt - fail again (max attempts reached, should go to DLQ)
     var claim2 = queue.awaitAndClaimTask(db).get(5, TimeUnit.SECONDS);
@@ -2105,10 +2105,11 @@ public class KeyedTaskQueueTest {
 
     assertThat(queue.getDlqSize().get(5, TimeUnit.SECONDS)).isEqualTo(0);
 
-    // Task should be immediately claimable with attempts reset
+    // Task should be immediately claimable with attempts representing the first attempt after redrive
     var redriven = queue.awaitAndClaimTask(db).get(5, TimeUnit.SECONDS);
     assertThat(redriven.task()).isEqualTo("redrive-data");
-    assertThat(redriven.taskProto().getAttempts()).isEqualTo(1); // reset
+    assertThat(redriven.taskProto().getAttempts())
+        .isEqualTo(1); // first attempt after redrive (counter reset on enqueue, incremented on claim)
     redriven.complete().get(5, TimeUnit.SECONDS);
   }
 
@@ -2270,5 +2271,56 @@ public class KeyedTaskQueueTest {
     List<DeadLetteredTask> dlqTasks = queue.listDlqTasks(10).get(5, TimeUnit.SECONDS);
     assertThat(dlqTasks).hasSize(1);
     assertThat(dlqTasks.get(0).getFailureReason()).isEqualTo("Database connection lost");
+  }
+
+  @Test
+  void testRedriveFromDlqByCount_negativeCount() throws ExecutionException, InterruptedException, TimeoutException {
+    var dlqConfig = TaskQueueConfig.builder(db, directory, new StringSerializer(), new StringSerializer())
+        .instantSource(() -> Instant.ofEpochMilli(simulatedTime.get()))
+        .maxAttempts(1)
+        .dlqEnabled(true)
+        .build();
+    var queue = KeyedTaskQueue.createOrOpen(dlqConfig, db).get();
+    assertThatThrownBy(() -> queue.redriveFromDlq(-1).get(5, TimeUnit.SECONDS))
+        .hasRootCauseInstanceOf(IllegalArgumentException.class)
+        .hasRootCauseMessage("count must be non-negative, but was -1");
+  }
+
+  @Test
+  void testRedriveFromDlqByCount_zeroCount() throws ExecutionException, InterruptedException, TimeoutException {
+    var dlqConfig = TaskQueueConfig.builder(db, directory, new StringSerializer(), new StringSerializer())
+        .instantSource(() -> Instant.ofEpochMilli(simulatedTime.get()))
+        .maxAttempts(1)
+        .dlqEnabled(true)
+        .build();
+    var queue = KeyedTaskQueue.createOrOpen(dlqConfig, db).get();
+    int result = queue.redriveFromDlq(0).get(5, TimeUnit.SECONDS);
+    assertThat(result).isEqualTo(0);
+  }
+
+  @Test
+  void testListDlqTasks_negativeLimit() throws ExecutionException, InterruptedException, TimeoutException {
+    var dlqConfig = TaskQueueConfig.builder(db, directory, new StringSerializer(), new StringSerializer())
+        .instantSource(() -> Instant.ofEpochMilli(simulatedTime.get()))
+        .maxAttempts(1)
+        .dlqEnabled(true)
+        .build();
+    var queue = KeyedTaskQueue.createOrOpen(dlqConfig, db).get();
+    assertThatThrownBy(() -> queue.listDlqTasks(-1).get(5, TimeUnit.SECONDS))
+        .hasRootCauseInstanceOf(IllegalArgumentException.class)
+        .hasRootCauseMessage("limit must be non-negative, but was -1");
+  }
+
+  @Test
+  void testRedriveFromDlqByKey_notFound() throws ExecutionException, InterruptedException, TimeoutException {
+    var dlqConfig = TaskQueueConfig.builder(db, directory, new StringSerializer(), new StringSerializer())
+        .instantSource(() -> Instant.ofEpochMilli(simulatedTime.get()))
+        .maxAttempts(1)
+        .dlqEnabled(true)
+        .build();
+    var queue = KeyedTaskQueue.createOrOpen(dlqConfig, db).get();
+    assertThatThrownBy(() -> queue.redriveFromDlq("nonexistent-key").get(5, TimeUnit.SECONDS))
+        .hasCauseInstanceOf(TaskQueueException.class)
+        .hasMessageContaining("No DLQ entry found");
   }
 }

--- a/src/test/java/io/github/panghy/taskqueue/KeyedTaskQueueTest.java
+++ b/src/test/java/io/github/panghy/taskqueue/KeyedTaskQueueTest.java
@@ -11,6 +11,7 @@ import com.apple.foundationdb.directory.DirectorySubspace;
 import com.apple.foundationdb.tuple.Tuple;
 import com.google.protobuf.ByteString;
 import com.google.protobuf.Timestamp;
+import io.github.panghy.taskqueue.proto.DeadLetteredTask;
 import io.github.panghy.taskqueue.proto.Task;
 import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.api.common.AttributeKey;
@@ -1988,5 +1989,286 @@ public class KeyedTaskQueueTest {
     // Now should be empty
     emptyFuture.get(5, TimeUnit.SECONDS);
     assertThat(emptyFuture.isDone()).isTrue();
+  }
+
+  // ---- Dead Letter Queue (DLQ) Tests ----
+
+  @Test
+  void testDlqDisabledByDefault_tasksDroppedAfterMaxAttempts()
+      throws ExecutionException, InterruptedException, TimeoutException {
+    // DLQ is disabled by default - tasks should be dropped after max attempts
+    var limitedConfig = TaskQueueConfig.builder(db, directory, new StringSerializer(), new StringSerializer())
+        .instantSource(() -> Instant.ofEpochMilli(simulatedTime.get()))
+        .maxAttempts(2)
+        .build();
+    var queue = KeyedTaskQueue.createOrOpen(limitedConfig, db).get();
+
+    queue.enqueue("drop-me", "task-data").get(5, TimeUnit.SECONDS);
+
+    // First attempt - fail
+    var claim1 = queue.awaitAndClaimTask(db).get(5, TimeUnit.SECONDS);
+    assertThat(claim1.taskProto().getAttempts()).isEqualTo(1);
+    claim1.fail();
+
+    // Second attempt - fail again (max attempts reached)
+    var claim2 = queue.awaitAndClaimTask(db).get(5, TimeUnit.SECONDS);
+    assertThat(claim2.taskProto().getAttempts()).isEqualTo(2);
+    claim2.fail().get(5, TimeUnit.SECONDS);
+
+    // Task should be dropped, not in DLQ
+    assertThat(queue.getDlqSize().get(5, TimeUnit.SECONDS)).isEqualTo(0);
+  }
+
+  @Test
+  void testDlqEnabled_tasksMoveToDlqAfterMaxAttempts()
+      throws ExecutionException, InterruptedException, TimeoutException {
+    var dlqConfig = TaskQueueConfig.builder(db, directory, new StringSerializer(), new StringSerializer())
+        .instantSource(() -> Instant.ofEpochMilli(simulatedTime.get()))
+        .maxAttempts(2)
+        .dlqEnabled(true)
+        .build();
+    var queue = KeyedTaskQueue.createOrOpen(dlqConfig, db).get();
+
+    queue.enqueue("dlq-task", "dlq-data").get(5, TimeUnit.SECONDS);
+
+    // First attempt - fail
+    var claim1 = queue.awaitAndClaimTask(db).get(5, TimeUnit.SECONDS);
+    claim1.fail();
+
+    // Second attempt - fail again (max attempts reached, should go to DLQ)
+    var claim2 = queue.awaitAndClaimTask(db).get(5, TimeUnit.SECONDS);
+    assertThat(claim2.taskProto().getAttempts()).isEqualTo(2);
+    claim2.fail().get(5, TimeUnit.SECONDS);
+
+    // Task should be in DLQ
+    assertThat(queue.getDlqSize().get(5, TimeUnit.SECONDS)).isEqualTo(1);
+  }
+
+  @Test
+  void testDlqFailureReasonStoredAndRetrievable() throws ExecutionException, InterruptedException, TimeoutException {
+    var dlqConfig = TaskQueueConfig.builder(db, directory, new StringSerializer(), new StringSerializer())
+        .instantSource(() -> Instant.ofEpochMilli(simulatedTime.get()))
+        .maxAttempts(1)
+        .dlqEnabled(true)
+        .build();
+    var queue = KeyedTaskQueue.createOrOpen(dlqConfig, db).get();
+
+    queue.enqueue("reason-task", "reason-data").get(5, TimeUnit.SECONDS);
+
+    var claim = queue.awaitAndClaimTask(db).get(5, TimeUnit.SECONDS);
+    claim.fail("Connection timeout").get(5, TimeUnit.SECONDS);
+
+    // Verify failure reason is stored
+    List<DeadLetteredTask> dlqTasks = queue.listDlqTasks(10).get(5, TimeUnit.SECONDS);
+    assertThat(dlqTasks).hasSize(1);
+    assertThat(dlqTasks.get(0).getFailureReason()).isEqualTo("Connection timeout");
+    assertThat(dlqTasks.get(0).getAttempts()).isEqualTo(1);
+  }
+
+  @Test
+  void testDlqFailTaskWithNullReason() throws ExecutionException, InterruptedException, TimeoutException {
+    var dlqConfig = TaskQueueConfig.builder(db, directory, new StringSerializer(), new StringSerializer())
+        .instantSource(() -> Instant.ofEpochMilli(simulatedTime.get()))
+        .maxAttempts(1)
+        .dlqEnabled(true)
+        .build();
+    var queue = KeyedTaskQueue.createOrOpen(dlqConfig, db).get();
+
+    queue.enqueue("null-reason", "data").get(5, TimeUnit.SECONDS);
+
+    var claim = queue.awaitAndClaimTask(db).get(5, TimeUnit.SECONDS);
+    claim.fail().get(5, TimeUnit.SECONDS); // null failure reason (backward compat)
+
+    List<DeadLetteredTask> dlqTasks = queue.listDlqTasks(10).get(5, TimeUnit.SECONDS);
+    assertThat(dlqTasks).hasSize(1);
+    assertThat(dlqTasks.get(0).getFailureReason()).isEmpty(); // null stored as empty string
+  }
+
+  @Test
+  void testRedriveFromDlqByKey() throws ExecutionException, InterruptedException, TimeoutException {
+    var dlqConfig = TaskQueueConfig.builder(db, directory, new StringSerializer(), new StringSerializer())
+        .instantSource(() -> Instant.ofEpochMilli(simulatedTime.get()))
+        .maxAttempts(1)
+        .dlqEnabled(true)
+        .build();
+    var queue = KeyedTaskQueue.createOrOpen(dlqConfig, db).get();
+
+    queue.enqueue("redrive-key", "redrive-data").get(5, TimeUnit.SECONDS);
+
+    var claim = queue.awaitAndClaimTask(db).get(5, TimeUnit.SECONDS);
+    claim.fail("test failure").get(5, TimeUnit.SECONDS);
+
+    assertThat(queue.getDlqSize().get(5, TimeUnit.SECONDS)).isEqualTo(1);
+
+    // Redrive by key
+    queue.redriveFromDlq("redrive-key").get(5, TimeUnit.SECONDS);
+
+    assertThat(queue.getDlqSize().get(5, TimeUnit.SECONDS)).isEqualTo(0);
+
+    // Task should be immediately claimable with attempts reset
+    var redriven = queue.awaitAndClaimTask(db).get(5, TimeUnit.SECONDS);
+    assertThat(redriven.task()).isEqualTo("redrive-data");
+    assertThat(redriven.taskProto().getAttempts()).isEqualTo(1); // reset
+    redriven.complete().get(5, TimeUnit.SECONDS);
+  }
+
+  @Test
+  void testRedriveFromDlqByCount() throws ExecutionException, InterruptedException, TimeoutException {
+    var dlqConfig = TaskQueueConfig.builder(db, directory, new StringSerializer(), new StringSerializer())
+        .instantSource(() -> Instant.ofEpochMilli(simulatedTime.get()))
+        .maxAttempts(1)
+        .dlqEnabled(true)
+        .build();
+    var queue = KeyedTaskQueue.createOrOpen(dlqConfig, db).get();
+
+    // Add 3 tasks to DLQ
+    for (int i = 1; i <= 3; i++) {
+      queue.enqueue("count-key-" + i, "count-data-" + i).get(5, TimeUnit.SECONDS);
+      var claim = queue.awaitAndClaimTask(db).get(5, TimeUnit.SECONDS);
+      claim.fail().get(5, TimeUnit.SECONDS);
+    }
+
+    assertThat(queue.getDlqSize().get(5, TimeUnit.SECONDS)).isEqualTo(3);
+
+    // Redrive 2 of 3
+    int redriven = queue.redriveFromDlq(2).get(5, TimeUnit.SECONDS);
+    assertThat(redriven).isEqualTo(2);
+    assertThat(queue.getDlqSize().get(5, TimeUnit.SECONDS)).isEqualTo(1);
+
+    // Claim the 2 redriven tasks
+    var c1 = queue.awaitAndClaimTask(db).get(5, TimeUnit.SECONDS);
+    var c2 = queue.awaitAndClaimTask(db).get(5, TimeUnit.SECONDS);
+    c1.complete().get(5, TimeUnit.SECONDS);
+    c2.complete().get(5, TimeUnit.SECONDS);
+  }
+
+  @Test
+  void testPurgeDlq() throws ExecutionException, InterruptedException, TimeoutException {
+    var dlqConfig = TaskQueueConfig.builder(db, directory, new StringSerializer(), new StringSerializer())
+        .instantSource(() -> Instant.ofEpochMilli(simulatedTime.get()))
+        .maxAttempts(1)
+        .dlqEnabled(true)
+        .build();
+    var queue = KeyedTaskQueue.createOrOpen(dlqConfig, db).get();
+
+    // Add 3 tasks to DLQ
+    for (int i = 1; i <= 3; i++) {
+      queue.enqueue("purge-key-" + i, "purge-data-" + i).get(5, TimeUnit.SECONDS);
+      var claim = queue.awaitAndClaimTask(db).get(5, TimeUnit.SECONDS);
+      claim.fail().get(5, TimeUnit.SECONDS);
+    }
+
+    assertThat(queue.getDlqSize().get(5, TimeUnit.SECONDS)).isEqualTo(3);
+
+    // Purge all
+    queue.purgeDlq().get(5, TimeUnit.SECONDS);
+
+    assertThat(queue.getDlqSize().get(5, TimeUnit.SECONDS)).isEqualTo(0);
+    assertThat(queue.listDlqTasks(10).get(5, TimeUnit.SECONDS)).isEmpty();
+  }
+
+  @Test
+  void testGetDlqSize() throws ExecutionException, InterruptedException, TimeoutException {
+    var dlqConfig = TaskQueueConfig.builder(db, directory, new StringSerializer(), new StringSerializer())
+        .instantSource(() -> Instant.ofEpochMilli(simulatedTime.get()))
+        .maxAttempts(1)
+        .dlqEnabled(true)
+        .build();
+    var queue = KeyedTaskQueue.createOrOpen(dlqConfig, db).get();
+
+    // Initially empty
+    assertThat(queue.getDlqSize().get(5, TimeUnit.SECONDS)).isEqualTo(0);
+
+    // Add one task to DLQ
+    queue.enqueue("size-key-1", "data-1").get(5, TimeUnit.SECONDS);
+    var claim1 = queue.awaitAndClaimTask(db).get(5, TimeUnit.SECONDS);
+    claim1.fail().get(5, TimeUnit.SECONDS);
+    assertThat(queue.getDlqSize().get(5, TimeUnit.SECONDS)).isEqualTo(1);
+
+    // Add another
+    queue.enqueue("size-key-2", "data-2").get(5, TimeUnit.SECONDS);
+    var claim2 = queue.awaitAndClaimTask(db).get(5, TimeUnit.SECONDS);
+    claim2.fail().get(5, TimeUnit.SECONDS);
+    assertThat(queue.getDlqSize().get(5, TimeUnit.SECONDS)).isEqualTo(2);
+
+    // Redrive one
+    queue.redriveFromDlq(1).get(5, TimeUnit.SECONDS);
+    assertThat(queue.getDlqSize().get(5, TimeUnit.SECONDS)).isEqualTo(1);
+
+    // Purge remaining
+    queue.purgeDlq().get(5, TimeUnit.SECONDS);
+    assertThat(queue.getDlqSize().get(5, TimeUnit.SECONDS)).isEqualTo(0);
+  }
+
+  @Test
+  void testListDlqTasksOrderAndLimit() throws ExecutionException, InterruptedException, TimeoutException {
+    var dlqConfig = TaskQueueConfig.builder(db, directory, new StringSerializer(), new StringSerializer())
+        .instantSource(() -> Instant.ofEpochMilli(simulatedTime.get()))
+        .maxAttempts(1)
+        .dlqEnabled(true)
+        .build();
+    var queue = KeyedTaskQueue.createOrOpen(dlqConfig, db).get();
+
+    // Add 3 tasks to DLQ
+    for (int i = 1; i <= 3; i++) {
+      queue.enqueue("list-key-" + i, "list-data-" + i).get(5, TimeUnit.SECONDS);
+      var claim = queue.awaitAndClaimTask(db).get(5, TimeUnit.SECONDS);
+      claim.fail("failure-" + i).get(5, TimeUnit.SECONDS);
+    }
+
+    // List all
+    List<DeadLetteredTask> allTasks = queue.listDlqTasks(10).get(5, TimeUnit.SECONDS);
+    assertThat(allTasks).hasSize(3);
+
+    // List with limit
+    List<DeadLetteredTask> limitedTasks = queue.listDlqTasks(2).get(5, TimeUnit.SECONDS);
+    assertThat(limitedTasks).hasSize(2);
+  }
+
+  @Test
+  void testRedrivenTaskIsImmediatelyClaimable() throws ExecutionException, InterruptedException, TimeoutException {
+    var dlqConfig = TaskQueueConfig.builder(db, directory, new StringSerializer(), new StringSerializer())
+        .instantSource(() -> Instant.ofEpochMilli(simulatedTime.get()))
+        .maxAttempts(1)
+        .dlqEnabled(true)
+        .build();
+    var queue = KeyedTaskQueue.createOrOpen(dlqConfig, db).get();
+
+    queue.enqueue("immediate-key", "immediate-data").get(5, TimeUnit.SECONDS);
+    var claim = queue.awaitAndClaimTask(db).get(5, TimeUnit.SECONDS);
+    claim.fail().get(5, TimeUnit.SECONDS);
+
+    // Redrive
+    queue.redriveFromDlq("immediate-key").get(5, TimeUnit.SECONDS);
+
+    // Should be immediately claimable (no delay)
+    var redriven = queue.awaitAndClaimTask(db).get(5, TimeUnit.SECONDS);
+    assertThat(redriven).isNotNull();
+    assertThat(redriven.task()).isEqualTo("immediate-data");
+    assertThat(redriven.taskProto().getAttempts()).isEqualTo(1);
+
+    // Complete and verify queue is empty
+    redriven.complete().get(5, TimeUnit.SECONDS);
+    assertQueueIsEmpty(queue);
+  }
+
+  @Test
+  void testFailTaskWithExplicitFailureReason() throws ExecutionException, InterruptedException, TimeoutException {
+    var dlqConfig = TaskQueueConfig.builder(db, directory, new StringSerializer(), new StringSerializer())
+        .instantSource(() -> Instant.ofEpochMilli(simulatedTime.get()))
+        .maxAttempts(1)
+        .dlqEnabled(true)
+        .build();
+    var queue = KeyedTaskQueue.createOrOpen(dlqConfig, db).get();
+
+    queue.enqueue("explicit-reason", "data").get(5, TimeUnit.SECONDS);
+    var claim = queue.awaitAndClaimTask(db).get(5, TimeUnit.SECONDS);
+
+    // Use explicit failTask with reason
+    queue.failTask(claim, "Database connection lost").get(5, TimeUnit.SECONDS);
+
+    List<DeadLetteredTask> dlqTasks = queue.listDlqTasks(10).get(5, TimeUnit.SECONDS);
+    assertThat(dlqTasks).hasSize(1);
+    assertThat(dlqTasks.get(0).getFailureReason()).isEqualTo("Database connection lost");
   }
 }

--- a/src/test/java/io/github/panghy/taskqueue/KeyedTaskQueueTest.java
+++ b/src/test/java/io/github/panghy/taskqueue/KeyedTaskQueueTest.java
@@ -2085,40 +2085,6 @@ public class KeyedTaskQueueTest {
   }
 
   @Test
-  void testRedriveFromDlqByKey() throws ExecutionException, InterruptedException, TimeoutException {
-    var dlqConfig = TaskQueueConfig.builder(db, directory, new StringSerializer(), new StringSerializer())
-        .instantSource(() -> Instant.ofEpochMilli(simulatedTime.get()))
-        .maxAttempts(1)
-        .dlqEnabled(true)
-        .build();
-    var queue = KeyedTaskQueue.createOrOpen(dlqConfig, db).get();
-
-    // Add two tasks to DLQ so the async iterator must scan past the first entry
-    queue.enqueue("redrive-key-1", "redrive-data-1").get(5, TimeUnit.SECONDS);
-    var claim1 = queue.awaitAndClaimTask(db).get(5, TimeUnit.SECONDS);
-    claim1.fail("test failure 1").get(5, TimeUnit.SECONDS);
-
-    simulatedTime.addAndGet(1000);
-    queue.enqueue("redrive-key-2", "redrive-data-2").get(5, TimeUnit.SECONDS);
-    var claim2 = queue.awaitAndClaimTask(db).get(5, TimeUnit.SECONDS);
-    claim2.fail("test failure 2").get(5, TimeUnit.SECONDS);
-
-    assertThat(queue.getDlqSize().get(5, TimeUnit.SECONDS)).isEqualTo(2);
-
-    // Redrive the second key (iterator must skip past the first entry)
-    queue.redriveFromDlq("redrive-key-2").get(5, TimeUnit.SECONDS);
-
-    assertThat(queue.getDlqSize().get(5, TimeUnit.SECONDS)).isEqualTo(1);
-
-    // Task should be immediately claimable with attempts representing the first attempt after redrive
-    var redriven = queue.awaitAndClaimTask(db).get(5, TimeUnit.SECONDS);
-    assertThat(redriven.task()).isEqualTo("redrive-data-2");
-    assertThat(redriven.taskProto().getAttempts())
-        .isEqualTo(1); // first attempt after redrive (counter reset on enqueue, incremented on claim)
-    redriven.complete().get(5, TimeUnit.SECONDS);
-  }
-
-  @Test
   void testRedriveFromDlqByCount() throws ExecutionException, InterruptedException, TimeoutException {
     var dlqConfig = TaskQueueConfig.builder(db, directory, new StringSerializer(), new StringSerializer())
         .instantSource(() -> Instant.ofEpochMilli(simulatedTime.get()))
@@ -2240,33 +2206,6 @@ public class KeyedTaskQueueTest {
   }
 
   @Test
-  void testRedrivenTaskIsImmediatelyClaimable() throws ExecutionException, InterruptedException, TimeoutException {
-    var dlqConfig = TaskQueueConfig.builder(db, directory, new StringSerializer(), new StringSerializer())
-        .instantSource(() -> Instant.ofEpochMilli(simulatedTime.get()))
-        .maxAttempts(1)
-        .dlqEnabled(true)
-        .build();
-    var queue = KeyedTaskQueue.createOrOpen(dlqConfig, db).get();
-
-    queue.enqueue("immediate-key", "immediate-data").get(5, TimeUnit.SECONDS);
-    var claim = queue.awaitAndClaimTask(db).get(5, TimeUnit.SECONDS);
-    claim.fail().get(5, TimeUnit.SECONDS);
-
-    // Redrive
-    queue.redriveFromDlq("immediate-key").get(5, TimeUnit.SECONDS);
-
-    // Should be immediately claimable (no delay)
-    var redriven = queue.awaitAndClaimTask(db).get(5, TimeUnit.SECONDS);
-    assertThat(redriven).isNotNull();
-    assertThat(redriven.task()).isEqualTo("immediate-data");
-    assertThat(redriven.taskProto().getAttempts()).isEqualTo(1);
-
-    // Complete and verify queue is empty
-    redriven.complete().get(5, TimeUnit.SECONDS);
-    assertQueueIsEmpty(queue);
-  }
-
-  @Test
   void testFailTaskWithExplicitFailureReason() throws ExecutionException, InterruptedException, TimeoutException {
     var dlqConfig = TaskQueueConfig.builder(db, directory, new StringSerializer(), new StringSerializer())
         .instantSource(() -> Instant.ofEpochMilli(simulatedTime.get()))
@@ -2325,15 +2264,58 @@ public class KeyedTaskQueueTest {
   }
 
   @Test
-  void testRedriveFromDlqByKey_notFound() throws ExecutionException, InterruptedException, TimeoutException {
+  void testBatchedRedrive() throws ExecutionException, InterruptedException, TimeoutException {
     var dlqConfig = TaskQueueConfig.builder(db, directory, new StringSerializer(), new StringSerializer())
         .instantSource(() -> Instant.ofEpochMilli(simulatedTime.get()))
         .maxAttempts(1)
         .dlqEnabled(true)
+        .dlqRedriveBatchSize(2)
         .build();
     var queue = KeyedTaskQueue.createOrOpen(dlqConfig, db).get();
-    assertThatThrownBy(() -> queue.redriveFromDlq("nonexistent-key").get(5, TimeUnit.SECONDS))
-        .hasCauseInstanceOf(TaskQueueException.class)
-        .hasMessageContaining("No DLQ entry found");
+
+    // Add 5 tasks to DLQ
+    for (int i = 1; i <= 5; i++) {
+      queue.enqueue("batch-key-" + i, "batch-data-" + i).get(5, TimeUnit.SECONDS);
+      var claim = queue.awaitAndClaimTask(db).get(5, TimeUnit.SECONDS);
+      claim.fail().get(5, TimeUnit.SECONDS);
+    }
+
+    assertThat(queue.getDlqSize().get(5, TimeUnit.SECONDS)).isEqualTo(5);
+
+    // Redrive all 5 — with batch size 2, this should use 3 transactions (2+2+1)
+    int redriven = queue.redriveFromDlq(5).get(5, TimeUnit.SECONDS);
+    assertThat(redriven).isEqualTo(5);
+    assertThat(queue.getDlqSize().get(5, TimeUnit.SECONDS)).isEqualTo(0);
+
+    // All 5 tasks should be claimable
+    for (int i = 0; i < 5; i++) {
+      var claim = queue.awaitAndClaimTask(db).get(5, TimeUnit.SECONDS);
+      claim.complete().get(5, TimeUnit.SECONDS);
+    }
+  }
+
+  @Test
+  void testBatchedRedrivePartialBatch() throws ExecutionException, InterruptedException, TimeoutException {
+    var dlqConfig = TaskQueueConfig.builder(db, directory, new StringSerializer(), new StringSerializer())
+        .instantSource(() -> Instant.ofEpochMilli(simulatedTime.get()))
+        .maxAttempts(1)
+        .dlqEnabled(true)
+        .dlqRedriveBatchSize(3)
+        .build();
+    var queue = KeyedTaskQueue.createOrOpen(dlqConfig, db).get();
+
+    // Add 2 tasks to DLQ
+    for (int i = 1; i <= 2; i++) {
+      queue.enqueue("partial-key-" + i, "partial-data-" + i).get(5, TimeUnit.SECONDS);
+      var claim = queue.awaitAndClaimTask(db).get(5, TimeUnit.SECONDS);
+      claim.fail().get(5, TimeUnit.SECONDS);
+    }
+
+    assertThat(queue.getDlqSize().get(5, TimeUnit.SECONDS)).isEqualTo(2);
+
+    // Request 10 but only 2 exist — should return 2
+    int redriven = queue.redriveFromDlq(10).get(5, TimeUnit.SECONDS);
+    assertThat(redriven).isEqualTo(2);
+    assertThat(queue.getDlqSize().get(5, TimeUnit.SECONDS)).isEqualTo(0);
   }
 }

--- a/src/test/java/io/github/panghy/taskqueue/SimpleTaskQueueWrapperTest.java
+++ b/src/test/java/io/github/panghy/taskqueue/SimpleTaskQueueWrapperTest.java
@@ -483,4 +483,35 @@ class SimpleTaskQueueWrapperTest {
     assertThat(dlqTasks).hasSize(1);
     assertThat(dlqTasks.get(0).getFailureReason()).isEmpty();
   }
+
+  @Test
+  void testBatchedRedrive() throws ExecutionException, InterruptedException, TimeoutException {
+    var dlqConfig = TaskQueueConfig.<String>builder(database, directory, new StringSerializer())
+        .instantSource(InstantSource.system())
+        .maxAttempts(1)
+        .dlqEnabled(true)
+        .dlqRedriveBatchSize(2)
+        .build();
+    var dlqQueue = TaskQueues.createSimpleTaskQueue(dlqConfig).get();
+
+    // Add 5 tasks to DLQ
+    for (int i = 1; i <= 5; i++) {
+      dlqQueue.enqueue("batch-task-" + i).get(5, TimeUnit.SECONDS);
+      var claim = dlqQueue.awaitAndClaimTask().get(5, TimeUnit.SECONDS);
+      dlqQueue.failTask(claim).get(5, TimeUnit.SECONDS);
+    }
+
+    assertThat(dlqQueue.getDlqSize().get(5, TimeUnit.SECONDS)).isEqualTo(5);
+
+    // Redrive all 5 — with batch size 2, this should use 3 transactions (2+2+1)
+    int redriven = dlqQueue.redriveFromDlq(5).get(5, TimeUnit.SECONDS);
+    assertThat(redriven).isEqualTo(5);
+    assertThat(dlqQueue.getDlqSize().get(5, TimeUnit.SECONDS)).isEqualTo(0);
+
+    // All 5 tasks should be claimable
+    for (int i = 0; i < 5; i++) {
+      var claim = dlqQueue.awaitAndClaimTask().get(5, TimeUnit.SECONDS);
+      dlqQueue.completeTask(claim).get(5, TimeUnit.SECONDS);
+    }
+  }
 }

--- a/src/test/java/io/github/panghy/taskqueue/SimpleTaskQueueWrapperTest.java
+++ b/src/test/java/io/github/panghy/taskqueue/SimpleTaskQueueWrapperTest.java
@@ -7,6 +7,7 @@ import com.apple.foundationdb.Database;
 import com.apple.foundationdb.FDB;
 import com.apple.foundationdb.directory.DirectoryLayer;
 import com.apple.foundationdb.directory.DirectorySubspace;
+import io.github.panghy.taskqueue.proto.DeadLetteredTask;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.time.Instant;
@@ -337,5 +338,149 @@ class SimpleTaskQueueWrapperTest {
     // Clean up
     TaskClaim<UUID, String> claim = taskQueue.awaitAndClaimTask().get();
     taskQueue.completeTask(claim).get();
+  }
+
+  // ---- Dead Letter Queue (DLQ) Tests ----
+
+  @Test
+  void testDlqEnabled_tasksMoveToDlqAfterMaxAttempts()
+      throws ExecutionException, InterruptedException, TimeoutException {
+    var dlqConfig = TaskQueueConfig.<String>builder(database, directory, new StringSerializer())
+        .instantSource(InstantSource.system())
+        .maxAttempts(2)
+        .dlqEnabled(true)
+        .build();
+    var dlqQueue = TaskQueues.createSimpleTaskQueue(dlqConfig).get();
+
+    dlqQueue.enqueue("dlq-simple-task").get(5, TimeUnit.SECONDS);
+
+    // First attempt - fail
+    var claim1 = dlqQueue.awaitAndClaimTask().get(5, TimeUnit.SECONDS);
+    dlqQueue.failTask(claim1).get(5, TimeUnit.SECONDS);
+
+    // Second attempt - fail again (max attempts reached)
+    var claim2 = dlqQueue.awaitAndClaimTask().get(5, TimeUnit.SECONDS);
+    assertThat(claim2.taskProto().getAttempts()).isEqualTo(2);
+    dlqQueue.failTask(claim2).get(5, TimeUnit.SECONDS);
+
+    // Task should be in DLQ
+    assertThat(dlqQueue.getDlqSize().get(5, TimeUnit.SECONDS)).isEqualTo(1);
+  }
+
+  @Test
+  void testDlqFailureReasonStoredAndRetrievable() throws ExecutionException, InterruptedException, TimeoutException {
+    var dlqConfig = TaskQueueConfig.<String>builder(database, directory, new StringSerializer())
+        .instantSource(InstantSource.system())
+        .maxAttempts(1)
+        .dlqEnabled(true)
+        .build();
+    var dlqQueue = TaskQueues.createSimpleTaskQueue(dlqConfig).get();
+
+    dlqQueue.enqueue("reason-task").get(5, TimeUnit.SECONDS);
+
+    var claim = dlqQueue.awaitAndClaimTask().get(5, TimeUnit.SECONDS);
+    dlqQueue.failTask(claim, "Timeout error").get(5, TimeUnit.SECONDS);
+
+    List<DeadLetteredTask> dlqTasks = dlqQueue.listDlqTasks(10).get(5, TimeUnit.SECONDS);
+    assertThat(dlqTasks).hasSize(1);
+    assertThat(dlqTasks.get(0).getFailureReason()).isEqualTo("Timeout error");
+  }
+
+  @Test
+  void testRedriveFromDlqByCount() throws ExecutionException, InterruptedException, TimeoutException {
+    var dlqConfig = TaskQueueConfig.<String>builder(database, directory, new StringSerializer())
+        .instantSource(InstantSource.system())
+        .maxAttempts(1)
+        .dlqEnabled(true)
+        .build();
+    var dlqQueue = TaskQueues.createSimpleTaskQueue(dlqConfig).get();
+
+    // Add 2 tasks to DLQ
+    dlqQueue.enqueue("task-a").get(5, TimeUnit.SECONDS);
+    var claimA = dlqQueue.awaitAndClaimTask().get(5, TimeUnit.SECONDS);
+    dlqQueue.failTask(claimA).get(5, TimeUnit.SECONDS);
+
+    dlqQueue.enqueue("task-b").get(5, TimeUnit.SECONDS);
+    var claimB = dlqQueue.awaitAndClaimTask().get(5, TimeUnit.SECONDS);
+    dlqQueue.failTask(claimB).get(5, TimeUnit.SECONDS);
+
+    assertThat(dlqQueue.getDlqSize().get(5, TimeUnit.SECONDS)).isEqualTo(2);
+
+    // Redrive all
+    int redriven = dlqQueue.redriveFromDlq(10).get(5, TimeUnit.SECONDS);
+    assertThat(redriven).isEqualTo(2);
+    assertThat(dlqQueue.getDlqSize().get(5, TimeUnit.SECONDS)).isEqualTo(0);
+
+    // Claim redriven tasks
+    var r1 = dlqQueue.awaitAndClaimTask().get(5, TimeUnit.SECONDS);
+    var r2 = dlqQueue.awaitAndClaimTask().get(5, TimeUnit.SECONDS);
+    dlqQueue.completeTask(r1).get(5, TimeUnit.SECONDS);
+    dlqQueue.completeTask(r2).get(5, TimeUnit.SECONDS);
+  }
+
+  @Test
+  void testPurgeDlq() throws ExecutionException, InterruptedException, TimeoutException {
+    var dlqConfig = TaskQueueConfig.<String>builder(database, directory, new StringSerializer())
+        .instantSource(InstantSource.system())
+        .maxAttempts(1)
+        .dlqEnabled(true)
+        .build();
+    var dlqQueue = TaskQueues.createSimpleTaskQueue(dlqConfig).get();
+
+    dlqQueue.enqueue("purge-task").get(5, TimeUnit.SECONDS);
+    var claim = dlqQueue.awaitAndClaimTask().get(5, TimeUnit.SECONDS);
+    dlqQueue.failTask(claim).get(5, TimeUnit.SECONDS);
+
+    assertThat(dlqQueue.getDlqSize().get(5, TimeUnit.SECONDS)).isEqualTo(1);
+
+    dlqQueue.purgeDlq().get(5, TimeUnit.SECONDS);
+
+    assertThat(dlqQueue.getDlqSize().get(5, TimeUnit.SECONDS)).isEqualTo(0);
+  }
+
+  @Test
+  void testGetDlqSizeEmpty() throws ExecutionException, InterruptedException, TimeoutException {
+    assertThat(taskQueue.getDlqSize().get(5, TimeUnit.SECONDS)).isEqualTo(0);
+  }
+
+  @Test
+  void testListDlqTasksWithLimit() throws ExecutionException, InterruptedException, TimeoutException {
+    var dlqConfig = TaskQueueConfig.<String>builder(database, directory, new StringSerializer())
+        .instantSource(InstantSource.system())
+        .maxAttempts(1)
+        .dlqEnabled(true)
+        .build();
+    var dlqQueue = TaskQueues.createSimpleTaskQueue(dlqConfig).get();
+
+    // Add 3 tasks to DLQ
+    for (int i = 1; i <= 3; i++) {
+      dlqQueue.enqueue("list-task-" + i).get(5, TimeUnit.SECONDS);
+      var claim = dlqQueue.awaitAndClaimTask().get(5, TimeUnit.SECONDS);
+      dlqQueue.failTask(claim).get(5, TimeUnit.SECONDS);
+    }
+
+    List<DeadLetteredTask> allTasks = dlqQueue.listDlqTasks(10).get(5, TimeUnit.SECONDS);
+    assertThat(allTasks).hasSize(3);
+
+    List<DeadLetteredTask> limitedTasks = dlqQueue.listDlqTasks(1).get(5, TimeUnit.SECONDS);
+    assertThat(limitedTasks).hasSize(1);
+  }
+
+  @Test
+  void testFailTaskWithNullReason() throws ExecutionException, InterruptedException, TimeoutException {
+    var dlqConfig = TaskQueueConfig.<String>builder(database, directory, new StringSerializer())
+        .instantSource(InstantSource.system())
+        .maxAttempts(1)
+        .dlqEnabled(true)
+        .build();
+    var dlqQueue = TaskQueues.createSimpleTaskQueue(dlqConfig).get();
+
+    dlqQueue.enqueue("null-reason-task").get(5, TimeUnit.SECONDS);
+    var claim = dlqQueue.awaitAndClaimTask().get(5, TimeUnit.SECONDS);
+    dlqQueue.failTask(claim).get(5, TimeUnit.SECONDS); // null reason
+
+    List<DeadLetteredTask> dlqTasks = dlqQueue.listDlqTasks(10).get(5, TimeUnit.SECONDS);
+    assertThat(dlqTasks).hasSize(1);
+    assertThat(dlqTasks.get(0).getFailureReason()).isEmpty();
   }
 }

--- a/src/test/java/io/github/panghy/taskqueue/TaskQueueConfigTest.java
+++ b/src/test/java/io/github/panghy/taskqueue/TaskQueueConfigTest.java
@@ -142,4 +142,39 @@ class TaskQueueConfigTest {
 
     assertFalse(config.isDlqEnabled());
   }
+
+  @Test
+  void testDlqRedriveBatchSizeDefault() {
+    TaskQueueConfig<String, String> config = TaskQueueConfig.builder(
+            db, directory, new StringSerializer(), new StringSerializer())
+        .build();
+
+    assertEquals(100, config.getDlqRedriveBatchSize());
+  }
+
+  @Test
+  void testDlqRedriveBatchSizeCustom() {
+    TaskQueueConfig<String, String> config = TaskQueueConfig.builder(
+            db, directory, new StringSerializer(), new StringSerializer())
+        .dlqRedriveBatchSize(50)
+        .build();
+
+    assertEquals(50, config.getDlqRedriveBatchSize());
+  }
+
+  @Test
+  void testDlqRedriveBatchSizeZeroThrows() {
+    assertThrows(IllegalArgumentException.class, () -> TaskQueueConfig.builder(
+            db, directory, new StringSerializer(), new StringSerializer())
+        .dlqRedriveBatchSize(0)
+        .build());
+  }
+
+  @Test
+  void testDlqRedriveBatchSizeNegativeThrows() {
+    assertThrows(IllegalArgumentException.class, () -> TaskQueueConfig.builder(
+            db, directory, new StringSerializer(), new StringSerializer())
+        .dlqRedriveBatchSize(-1)
+        .build());
+  }
 }

--- a/src/test/java/io/github/panghy/taskqueue/TaskQueueConfigTest.java
+++ b/src/test/java/io/github/panghy/taskqueue/TaskQueueConfigTest.java
@@ -1,7 +1,9 @@
 package io.github.panghy.taskqueue;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.apple.foundationdb.Database;
 import com.apple.foundationdb.FDB;
@@ -110,5 +112,34 @@ class TaskQueueConfigTest {
             db, directory, new StringSerializer(), new StringSerializer())
         .defaultThrottle(Duration.ofSeconds(-1))
         .build());
+  }
+
+  @Test
+  void testDlqDisabledByDefault() {
+    TaskQueueConfig<String, String> config = TaskQueueConfig.builder(
+            db, directory, new StringSerializer(), new StringSerializer())
+        .build();
+
+    assertFalse(config.isDlqEnabled());
+  }
+
+  @Test
+  void testDlqEnabled() {
+    TaskQueueConfig<String, String> config = TaskQueueConfig.builder(
+            db, directory, new StringSerializer(), new StringSerializer())
+        .dlqEnabled(true)
+        .build();
+
+    assertTrue(config.isDlqEnabled());
+  }
+
+  @Test
+  void testDlqExplicitlyDisabled() {
+    TaskQueueConfig<String, String> config = TaskQueueConfig.builder(
+            db, directory, new StringSerializer(), new StringSerializer())
+        .dlqEnabled(false)
+        .build();
+
+    assertFalse(config.isDlqEnabled());
   }
 }


### PR DESCRIPTION
**Summary:** Implements comprehensive Dead Letter Queue functionality for the taskqueue library, allowing tasks that exceed max attempts to be moved to a DLQ instead of being silently dropped. Includes APIs to redrive tasks back to the main queue, purge the DLQ, and track failure reasons for each task.

**Changes:**
- **Protobuf:** Added `DeadLetteredTask` message to store dead-lettered tasks with failure reasons, creation time, and attempt count
- **Configuration:** Added `dlqEnabled` flag to `TaskQueueConfig` (disabled by default for backward compatibility)
- **TaskQueue Interface:** Added DLQ management methods:
  - `redriveFromDlq(K taskKey)` - redrive specific task by key
  - `redriveFromDlq(int count)` - redrive up to N oldest tasks
  - `purgeDlq()` - clear all DLQ entries
  - `getDlqSize()` - get count of tasks in DLQ
  - `listDlqTasks(int limit)` - list DLQ entries ordered oldest first
- **TaskClaim:** Enhanced `fail()` methods to accept optional `String failureReason` parameter; backward-compatible `fail()` with no args still works
- **SimpleTaskQueue:** Exposed all DLQ APIs for simple (non-keyed) task queues
- **Implementation:** Tasks exceeding `maxAttempts` are moved to DLQ when enabled; redriven tasks start with attempts=0 and immediate visibility

**Testing:**
- Added comprehensive DLQ tests covering: task movement to DLQ, failure reason storage, redrive by key/count, purge, size queries, and list operations
- Verified backward compatibility with null failure reasons
- Confirmed redriven tasks are immediately claimable with reset attempt count
- All existing tests pass unchanged

**Checklist:**
- [x] DLQ disabled by default (no behavior change for existing users)
- [x] Tasks moved to DLQ after exceeding maxAttempts
- [x] Failure reasons tracked and retrievable
- [x] Redrive APIs support both single task and batch operations
- [x] Code coverage meets 80% line / 70% branch thresholds
- [x] All acceptance criteria met

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author